### PR TITLE
Support SDL_SetWindowTitle

### DIFF
--- a/Sources/SDL/Window.swift
+++ b/Sources/SDL/Window.swift
@@ -104,6 +104,21 @@ public final class SDLWindow {
             return SDL_SetWindowDisplayMode(internalPointer, nil) >= 0
         }
     }
+    
+    /// Set the title of a window
+    public var title: String {
+        
+        get {
+            
+            return String(cString: SDL_GetWindowTitle(internalPointer))
+            
+        }
+        set {
+            
+            SDL_SetWindowTitle(internalPointer, newValue)
+            
+        }
+    }
 }
 
 // MARK: - Supporting Types


### PR DESCRIPTION
I added `Window.setTitle` function for calling [SDL_SetWindowTitle](https://wiki.libsdl.org/SDL_SetWindowTitle).