### PR TITLE
Fixed problem with UInt32 initializer

### DIFF
--- a/Sources/SDL/PixelFormat.swift
+++ b/Sources/SDL/PixelFormat.swift
@@ -73,18 +73,18 @@ internal extension SDLPixelFormat.Format {
 public extension SDLPixelFormat.Format {
     
     /// SDL_PIXELFORMAT_INDEX1LSB
-    static let index1LSB = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_INDEX1LSB))
+    static let index1LSB = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_INDEX1LSB.rawValue))
     
     /// SDL_PIXELFORMAT_INDEX1MSB
-    static let index1MSB = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_INDEX1MSB))
+    static let index1MSB = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_INDEX1MSB.rawValue))
     
     #if os(macOS)
     /// SDL_PIXELFORMAT_ARGB32
-    static let argb32 = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_ARGB32))
+    static let argb32 = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_ARGB32.rawValue))
     #endif
     
     /// SDL_PIXELFORMAT_ARGB8888
-    static let argb8888 = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_ARGB8888))
+    static let argb8888 = SDLPixelFormat.Format(rawValue: UInt32(SDL_PIXELFORMAT_ARGB8888.rawValue))
 }
 
 // MARK: - ExpressibleByIntegerLiteral


### PR DESCRIPTION
`swift run` was failing due to a bad initializer. Hopefully you can merge this.

Thanks for the library!