### PR TITLE
Add SDL_image/SDL_mixer support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,22 @@ let package = Package(
             targets: ["SDL3Swift"]
         ),
         .library(
+            name: "SDL2Image",
+            targets: ["SDL2Image"]
+        ),
+        .library(
+            name: "SDL2Mixer",
+            targets: ["SDL2Mixer"]
+        ),
+        .library(
+            name: "SDL3Image",
+            targets: ["SDL3Image"]
+        ),
+        .library(
+            name: "SDL3Mixer",
+            targets: ["SDL3Mixer"]
+        ),
+        .library(
             name: "CSDL2Image",
             targets: ["CSDL2Image"]
         ),
@@ -66,6 +82,28 @@ let package = Package(
                 .brew(["sdl3"]),
                 .apt(["libsdl3-dev"])
             ]
+        ),
+        // Separate, opt-in targets: consumers that don't need image loading or audio playback
+        // don't pay for (or need to install) SDL_image / SDL_mixer at all.
+        .target(
+            name: "SDL2Image",
+            dependencies: ["SDL2Swift", "CSDL2Image"],
+            path: "Sources/SDL2Image"
+        ),
+        .target(
+            name: "SDL2Mixer",
+            dependencies: ["SDL2Swift", "CSDL2Mixer"],
+            path: "Sources/SDL2Mixer"
+        ),
+        .target(
+            name: "SDL3Image",
+            dependencies: ["SDL3Swift", "CSDL3Image"],
+            path: "Sources/SDL3Image"
+        ),
+        .target(
+            name: "SDL3Mixer",
+            dependencies: ["SDL3Swift", "CSDL3Mixer"],
+            path: "Sources/SDL3Mixer"
         ),
         .systemLibrary(
             name: "CSDL2Image",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # SDL
 Swift library for SDL2 and SDL3
 
-- `SDL2Swift`: Swift wrapper for [SDL2](https://www.libsdl.org/).
-- `SDL3Swift`: Swift wrapper for [SDL3](https://www.libsdl.org/).
-- `CSDL2Image` / `CSDL3Image`: raw C module for [SDL_image](https://github.com/libsdl-org/SDL_image), for image loading.
-- `CSDL2Mixer` / `CSDL3Mixer`: raw C module for [SDL_mixer](https://github.com/libsdl-org/SDL_mixer), for audio playback.
+Each capability is its own product, so clients only pull in the dependencies (and system
+libraries) they actually need:
+
+- `SDL2Swift` / `SDL3Swift`: Swift wrapper for [SDL2](https://www.libsdl.org/) / [SDL3](https://www.libsdl.org/) core.
+- `SDL2Image` / `SDL3Image`: Swift wrapper for image loading via [SDL_image](https://github.com/libsdl-org/SDL_image), depends on `SDL2Swift` / `SDL3Swift`.
+- `SDL2Mixer`: Swift wrapper for [SDL_mixer](https://github.com/libsdl-org/SDL_mixer)'s classic `Mix_*` audio API, depends on `SDL2Swift`.
+- `SDL3Mixer`: Swift wrapper for `SDL_mixer`'s new `MIX_*` audio API, depends on `SDL3Swift`.
+- `CSDL2Image` / `CSDL3Image`: raw C module for `SDL_image`, for direct interop.
+- `CSDL2Mixer` / `CSDL3Mixer`: raw C module for `SDL_mixer`, for direct interop.

--- a/Sources/SDL2/Error.swift
+++ b/Sources/SDL2/Error.swift
@@ -9,10 +9,15 @@ import CSDL2
 
 /// SDL Error
 public struct SDLError: Error {
-    
+
     public let errorMessage: String
-    
+
     public let context: Context?
+
+    public init(errorMessage: String, context: Context? = nil) {
+        self.errorMessage = errorMessage
+        self.context = context
+    }
 }
 
 extension SDLError: CustomStringConvertible {
@@ -46,7 +51,7 @@ public extension SDLError {
         
         public let line: UInt
         
-        internal init(file: String,
+        public init(file: String,
                       type: StaticString,
                       function: String,
                       line: UInt) {
@@ -64,7 +69,7 @@ public extension SDLError {
     }
 }
 
-internal extension SDLError {
+public extension SDLError {
     
     /// Text for last reported error.
     static func current(context: Context? = nil) -> SDLError? {
@@ -79,7 +84,7 @@ internal extension SDLError {
     }
 }
 
-internal extension CInt {
+public extension CInt {
     
     /// Throws for error codes.
     @inline(__always)
@@ -101,7 +106,7 @@ internal extension CInt {
     }
 }
 
-internal extension Optional {
+public extension Optional {
 
     /// Unwraps optional value, throwing error if nil.
     @inline(__always)

--- a/Sources/SDL2/Renderer.swift
+++ b/Sources/SDL2/Renderer.swift
@@ -13,9 +13,12 @@ public final class SDLRenderer {
     // MARK: - Properties
     
     internal let internalPointer: OpaquePointer
-    
+
+    /// The underlying `SDL_Renderer` pointer, for interop with other `SDL_*` C APIs.
+    public var unsafePointer: OpaquePointer { internalPointer }
+
     // MARK: - Initialization
-    
+
     deinit {
         SDL_DestroyRenderer(internalPointer)
     }

--- a/Sources/SDL2Image/Image.swift
+++ b/Sources/SDL2Image/Image.swift
@@ -1,0 +1,29 @@
+//
+//  Image.swift
+//  SDL2Image
+//
+//  Created by Alsey Coleman Miller on 6/6/17.
+//
+
+import SDL2Swift
+import CSDL2Image
+
+public extension SDLSurface {
+
+    /// Load an image file (any format supported by `SDL_image`) into a new surface.
+    convenience init(contentsOfFile path: String) throws(SDLError) {
+
+        let pointer = IMG_Load(path)
+        self.init(unsafePointer: try pointer.sdlThrow(type: "SDLSurface"))
+    }
+}
+
+public extension SDLTexture {
+
+    /// Load an image file (any format supported by `SDL_image`) directly into a new texture.
+    convenience init(renderer: SDLRenderer, contentsOfFile path: String) throws(SDLError) {
+
+        let pointer = IMG_LoadTexture(renderer.unsafePointer, path)
+        self.init(unsafePointer: try pointer.sdlThrow(type: "SDLTexture"))
+    }
+}

--- a/Sources/SDL2Mixer/Mixer.swift
+++ b/Sources/SDL2Mixer/Mixer.swift
@@ -1,0 +1,126 @@
+//
+//  Mixer.swift
+//  SDL2Mixer
+//
+//  Created by Alsey Coleman Miller on 6/6/17.
+//
+
+import SDL2Swift
+import CSDL2Mixer
+
+public extension SDL {
+
+    /// Initialize `SDL_mixer` for the given audio file formats.
+    static func initializeMixer(formats: BitMaskOptionSet<SDLMixerFormat>) throws(SDLError) {
+
+        let flags = formats.rawValue
+        guard Mix_Init(flags) & flags == flags else {
+            let context = SDLError.Context(file: #file, type: "SDL", function: #function, line: #line)
+            throw SDLError.current(context: context) ?? SDLError(errorMessage: "Mix_Init failed", context: context)
+        }
+    }
+
+    /// Shut down and clean up `SDL_mixer`.
+    static func quitMixer() {
+        Mix_Quit()
+    }
+
+    /// Open the default audio device for playback with `SDL_mixer`.
+    static func openAudio(frequency: Int32 = 44100, format: UInt16 = UInt16(AUDIO_S16LSB), channels: Int32 = 2, chunkSize: Int32 = 2048) throws(SDLError) {
+
+        try Mix_OpenAudio(frequency, format, channels, chunkSize).sdlThrow(type: "SDL")
+    }
+
+    /// Close the audio device opened with `openAudio(frequency:format:channels:chunkSize:)`.
+    static func closeAudio() {
+        Mix_CloseAudio()
+    }
+}
+
+/// Audio file formats that can be requested when initializing `SDL_mixer`.
+public enum SDLMixerFormat: Int32, BitMaskOption {
+
+    case flac = 0x00000001
+    case mod = 0x00000002
+    case mp3 = 0x00000008
+    case ogg = 0x00000010
+    case mid = 0x00000020
+    case opus = 0x00000040
+    case wavpack = 0x00000080
+}
+
+/// A pre-decoded, short audio sample (`Mix_Chunk`) played on an automatically-selected channel.
+public final class SDLAudioChunk {
+
+    // MARK: - Properties
+
+    internal let internalPointer: UnsafeMutablePointer<Mix_Chunk>
+
+    // MARK: - Initialization
+
+    deinit {
+        Mix_FreeChunk(internalPointer)
+    }
+
+    /// Load a WAV, OGG, or other supported audio file as a chunk.
+    public init(contentsOfFile path: String) throws(SDLError) {
+
+        let internalPointer = Mix_LoadWAV(path)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLAudioChunk")
+    }
+
+    // MARK: - Methods
+
+    /// Play the chunk on the first free channel.
+    ///
+    /// - Parameter loops: The number of times to loop, or `-1` to loop forever.
+    /// - Returns: The channel the chunk is playing on.
+    @discardableResult
+    public func play(loops: Int32 = 0) throws(SDLError) -> Int32 {
+        let channel = Mix_PlayChannel(-1, internalPointer, loops)
+        try channel.sdlThrow(type: "SDLAudioChunk")
+        return channel
+    }
+}
+
+/// A single streamed music track (`Mix_Music`).
+public final class SDLMusic {
+
+    // MARK: - Properties
+
+    internal let internalPointer: OpaquePointer
+
+    // MARK: - Initialization
+
+    deinit {
+        Mix_FreeMusic(internalPointer)
+    }
+
+    /// Load a music file for streamed playback.
+    public init(contentsOfFile path: String) throws(SDLError) {
+
+        let internalPointer = Mix_LoadMUS(path)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLMusic")
+    }
+
+    // MARK: - Accessors
+
+    /// Whether music is actively playing.
+    public static var isPlaying: Bool {
+        Mix_PlayingMusic() != 0
+    }
+
+    // MARK: - Methods
+
+    /// Play the music.
+    ///
+    /// - Parameter loops: The number of times to loop, or `-1` to loop forever.
+    public func play(loops: Int32 = -1) throws(SDLError) {
+        try Mix_PlayMusic(internalPointer, loops).sdlThrow(type: "SDLMusic")
+    }
+
+    /// Stop the currently playing music.
+    public static func halt() throws(SDLError) {
+        try Mix_HaltMusic().sdlThrow(type: "SDLMusic")
+    }
+}

--- a/Sources/SDL3/Error.swift
+++ b/Sources/SDL3/Error.swift
@@ -13,6 +13,11 @@ public struct SDLError: Error {
     public let errorMessage: String
 
     public let context: Context?
+
+    public init(errorMessage: String, context: Context? = nil) {
+        self.errorMessage = errorMessage
+        self.context = context
+    }
 }
 
 extension SDLError: CustomStringConvertible {
@@ -46,7 +51,7 @@ public extension SDLError {
 
         public let line: UInt
 
-        internal init(file: String,
+        public init(file: String,
                       type: StaticString,
                       function: String,
                       line: UInt) {
@@ -64,7 +69,7 @@ public extension SDLError {
     }
 }
 
-internal extension SDLError {
+public extension SDLError {
 
     /// Text for last reported error.
     static func current(context: Context? = nil) -> SDLError? {
@@ -79,7 +84,7 @@ internal extension SDLError {
     }
 }
 
-internal extension Bool {
+public extension Bool {
 
     /// Throws for `false` return values.
     @inline(__always)
@@ -101,7 +106,7 @@ internal extension Bool {
     }
 }
 
-internal extension Optional {
+public extension Optional {
 
     /// Unwraps optional value, throwing error if nil.
     @inline(__always)

--- a/Sources/SDL3/Renderer.swift
+++ b/Sources/SDL3/Renderer.swift
@@ -14,6 +14,9 @@ public final class SDLRenderer {
 
     internal let internalPointer: OpaquePointer
 
+    /// The underlying `SDL_Renderer` pointer, for interop with other `SDL_*` C APIs.
+    public var unsafePointer: OpaquePointer { internalPointer }
+
     // MARK: - Initialization
 
     deinit {

--- a/Sources/SDL3Image/Image.swift
+++ b/Sources/SDL3Image/Image.swift
@@ -1,0 +1,29 @@
+//
+//  Image.swift
+//  SDL3Image
+//
+//  Created by Alsey Coleman Miller on 6/6/17.
+//
+
+import SDL3Swift
+import CSDL3Image
+
+public extension SDLSurface {
+
+    /// Load an image file (any format supported by `SDL_image`) into a new surface.
+    convenience init(contentsOfFile path: String) throws(SDLError) {
+
+        let pointer = IMG_Load(path)
+        self.init(unsafePointer: try pointer.sdlThrow(type: "SDLSurface"))
+    }
+}
+
+public extension SDLTexture {
+
+    /// Load an image file (any format supported by `SDL_image`) directly into a new texture.
+    convenience init(renderer: SDLRenderer, contentsOfFile path: String) throws(SDLError) {
+
+        let pointer = IMG_LoadTexture(renderer.unsafePointer, path)
+        self.init(unsafePointer: try pointer.sdlThrow(type: "SDLTexture"))
+    }
+}

--- a/Sources/SDL3Mixer/Mixer.swift
+++ b/Sources/SDL3Mixer/Mixer.swift
@@ -1,0 +1,125 @@
+//
+//  Mixer.swift
+//  SDL3Mixer
+//
+//  Created by Alsey Coleman Miller on 6/6/17.
+//
+
+import SDL3Swift
+import CSDL3Mixer
+
+public extension SDL {
+
+    /// Initialize `SDL_mixer`.
+    static func initializeMixer() throws(SDLError) {
+        try MIX_Init().sdlThrow(type: "SDL")
+    }
+
+    /// Shut down and clean up `SDL_mixer`.
+    static func quitMixer() {
+        MIX_Quit()
+    }
+}
+
+/// An audio mixer device (`MIX_Mixer`), shared by every `SDLAudioTrack` and one-shot
+/// `SDLAudio.play(on:)` call.
+public final class SDLMixer {
+
+    // MARK: - Properties
+
+    internal let internalPointer: OpaquePointer
+
+    // MARK: - Initialization
+
+    deinit {
+        MIX_DestroyMixer(internalPointer)
+    }
+
+    /// Open an audio device for mixed playback.
+    public init(device: AudioDeviceID = SDL.defaultPlaybackAudioDevice) throws(SDLError) {
+
+        let internalPointer = MIX_CreateMixerDevice(device.rawValue, nil)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLMixer")
+    }
+
+    // MARK: - Methods
+
+    /// Play a loaded audio sample once, on an automatically-managed track.
+    public func play(_ audio: SDLAudio) throws(SDLError) {
+        try MIX_PlayAudio(internalPointer, audio.internalPointer).sdlThrow(type: "SDLMixer")
+    }
+}
+
+/// A loaded (and optionally pre-decoded) audio asset (`MIX_Audio`) - a sound effect or music
+/// track ready to be played via `SDLMixer.play(_:)` or assigned to an `SDLAudioTrack`.
+public final class SDLAudio {
+
+    // MARK: - Properties
+
+    internal let internalPointer: OpaquePointer
+
+    // MARK: - Initialization
+
+    deinit {
+        MIX_DestroyAudio(internalPointer)
+    }
+
+    /// Load an audio file (WAV, OGG, and other formats bundled with `SDL_mixer`).
+    ///
+    /// - Parameter predecode: Decode the entire file up front instead of streaming it,
+    ///   trading memory for lower per-play latency. Appropriate for short sound effects,
+    ///   not for music.
+    public init(mixer: SDLMixer, contentsOfFile path: String, predecode: Bool = false) throws(SDLError) {
+
+        let internalPointer = MIX_LoadAudio(mixer.internalPointer, path, predecode)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLAudio")
+    }
+}
+
+/// A single playback slot (`MIX_Track`) that an `SDLAudio` can be assigned to and played on,
+/// used here for the one music track that streams at a time.
+public final class SDLAudioTrack {
+
+    // MARK: - Properties
+
+    internal let internalPointer: OpaquePointer
+
+    // MARK: - Initialization
+
+    deinit {
+        MIX_DestroyTrack(internalPointer)
+    }
+
+    /// Create a new track on the given mixer.
+    public init(mixer: SDLMixer) throws(SDLError) {
+
+        let internalPointer = MIX_CreateTrack(mixer.internalPointer)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLAudioTrack")
+    }
+
+    // MARK: - Accessors
+
+    /// Whether the track is currently playing.
+    public var isPlaying: Bool {
+        MIX_TrackPlaying(internalPointer)
+    }
+
+    // MARK: - Methods
+
+    /// Assign the audio to be played on this track.
+    public func setAudio(_ audio: SDLAudio) throws(SDLError) {
+        try MIX_SetTrackAudio(internalPointer, audio.internalPointer).sdlThrow(type: "SDLAudioTrack")
+    }
+
+    /// Play the track's currently assigned audio.
+    public func play() throws(SDLError) {
+        try MIX_PlayTrack(internalPointer, 0).sdlThrow(type: "SDLAudioTrack")
+    }
+
+    /// Stop playback on this track.
+    ///
+    /// - Parameter fadeOutFrames: The number of sample frames to fade out over, or `0` to stop immediately.
+    public func stop(fadeOutFrames: Int64 = 0) throws(SDLError) {
+        try MIX_StopTrack(internalPointer, fadeOutFrames).sdlThrow(type: "SDLAudioTrack")
+    }
+}


### PR DESCRIPTION
- Adds modular, opt-in `SDL2Image`/`SDL3Image` (image loading via `SDL_image`) and `SDL2Mixer`/`SDL3Mixer` (audio playback via `SDL_mixer`'s classic `Mix_*` API on SDL2 and the new `MIX_*` API on SDL3) targets/products, each depending only on the corresponding `*Swift` target plus its own `CSDL*Image`/`CSDL*Mixer` system library — so consumers that don't need image/audio don't pull those dependencies in at all. Raw `CSDL2Image`/`CSDL2Mixer`/`CSDL3Image`/`CSDL3Mixer` system-library targets are also exposed directly as products for consumers who want to call the C API themselves.