### PR TITLE
Add SDL3Swift wrappers for OpenGL, keyboard, mouse, and misc APIs

### DIFF
--- a/Sources/SDL3/Event.swift
+++ b/Sources/SDL3/Event.swift
@@ -36,6 +36,9 @@ public enum SDLEvent {
     case gamepadRemoved(which: JoystickID)
     case gamepadButtonDown(which: JoystickID, button: SDLGamepad.Button)
     case gamepadButtonUp(which: JoystickID, button: SDLGamepad.Button)
+    case mouseWheel(windowID: UInt32, x: Float, y: Float)
+    case textInput(windowID: UInt32, text: String)
+    case windowCloseRequested(windowID: UInt32)
 
     /// An event that isn't yet modeled by `SDLEvent`. The raw `SDL_EventType` value is preserved.
     case unknown(UInt32)
@@ -82,6 +85,15 @@ public enum SDLEvent {
 
         case SDL_EVENT_GAMEPAD_BUTTON_UP:
             self = .gamepadButtonUp(which: JoystickID(rawValue: event.gbutton.which), button: SDLGamepad.Button(rawValue: Int32(event.gbutton.button)))
+
+        case SDL_EVENT_MOUSE_WHEEL:
+            self = .mouseWheel(windowID: event.wheel.windowID, x: event.wheel.x, y: event.wheel.y)
+
+        case SDL_EVENT_TEXT_INPUT:
+            self = .textInput(windowID: event.text.windowID, text: String(cString: event.text.text))
+
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            self = .windowCloseRequested(windowID: event.window.windowID)
 
         default:
             self = .unknown(event.type)

--- a/Sources/SDL3/Gamepad.swift
+++ b/Sources/SDL3/Gamepad.swift
@@ -45,6 +45,32 @@ public final class SDLGamepad: Identifiable {
     public func isPressed(_ button: Button) -> Bool {
         SDL_GetGamepadButton(internalPointer, SDL_GamepadButton(rawValue: button.rawValue))
     }
+
+    /// The implementation dependent name of the gamepad.
+    public var name: String? {
+        guard let cString = SDL_GetGamepadName(internalPointer) else { return nil }
+        return String(cString: cString)
+    }
+
+    /// The properties associated with this gamepad.
+    public var properties: SDLProperties {
+        SDLProperties(rawValue: SDL_GetGamepadProperties(internalPointer))
+    }
+
+    /// Whether the gamepad has a rumble motor.
+    public var hasRumble: Bool {
+        properties.boolean(SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN)
+    }
+
+    /// Start a rumble effect on the gamepad.
+    public func rumble(lowFrequency: UInt16, highFrequency: UInt16, duration milliseconds: UInt32) throws(SDLError) {
+        try SDL_RumbleGamepad(internalPointer, lowFrequency, highFrequency, milliseconds).sdlThrow(type: "SDLGamepad")
+    }
+
+    /// Set the player index of the gamepad.
+    public func setPlayerIndex(_ playerIndex: Int32) throws(SDLError) {
+        try SDL_SetGamepadPlayerIndex(internalPointer, playerIndex).sdlThrow(type: "SDLGamepad")
+    }
 }
 
 // MARK: - Supporting Types
@@ -95,5 +121,39 @@ public extension SDLGamepad {
         public static var dpadDown: Button { Button(rawValue: SDL_GAMEPAD_BUTTON_DPAD_DOWN.rawValue) }
         public static var dpadLeft: Button { Button(rawValue: SDL_GAMEPAD_BUTTON_DPAD_LEFT.rawValue) }
         public static var dpadRight: Button { Button(rawValue: SDL_GAMEPAD_BUTTON_DPAD_RIGHT.rawValue) }
+    }
+}
+
+public extension SDLGamepad.Axis {
+
+    /// A human-readable name for the axis, or `nil` if it doesn't have one.
+    var stringValue: String? {
+        guard let cString = SDL_GetGamepadStringForAxis(SDL_GamepadAxis(rawValue: rawValue)) else { return nil }
+        return String(cString: cString)
+    }
+}
+
+public extension SDLGamepad.Button {
+
+    /// A human-readable name for the button, or `nil` if it doesn't have one.
+    var stringValue: String? {
+        guard let cString = SDL_GetGamepadStringForButton(SDL_GamepadButton(rawValue: rawValue)) else { return nil }
+        return String(cString: cString)
+    }
+}
+
+public extension SDL {
+
+    /// Add support for gamepads that SDL is unaware of, loading a mapping file.
+    static func addGamepadMappings(fromFile path: String) throws(SDLError) -> Int32 {
+
+        let count = SDL_AddGamepadMappingsFromFile(path)
+        try (count >= 0).sdlThrow(type: "SDL")
+        return count
+    }
+
+    /// Whether the given joystick is supported by the gamepad interface.
+    static func isGamepad(_ joystickID: JoystickID) -> Bool {
+        SDL_IsGamepad(joystickID.rawValue)
     }
 }

--- a/Sources/SDL3/Joystick.swift
+++ b/Sources/SDL3/Joystick.swift
@@ -1,0 +1,30 @@
+//
+//  Joystick.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+public extension SDL {
+
+    /// A list of currently connected joysticks.
+    static var joystickIDs: [JoystickID] {
+
+        var count: Int32 = 0
+        guard let pointer = SDL_GetJoysticks(&count) else { return [] }
+        defer { SDL_free(pointer) }
+        return (0 ..< Int(count)).map { JoystickID(rawValue: pointer[$0]) }
+    }
+}
+
+public extension JoystickID {
+
+    /// The implementation dependent name of the joystick.
+    var name: String? {
+
+        guard let cString = SDL_GetJoystickNameForID(rawValue) else { return nil }
+        return String(cString: cString)
+    }
+}

--- a/Sources/SDL3/Keyboard.swift
+++ b/Sources/SDL3/Keyboard.swift
@@ -1,0 +1,102 @@
+//
+//  Keyboard.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+public extension SDL {
+
+    /// A snapshot of the current state of the keyboard, indexed by `Scancode.rawValue`.
+    static var keyboardState: [Bool] {
+
+        var count: Int32 = 0
+        guard let pointer = SDL_GetKeyboardState(&count) else { return [] }
+        return (0 ..< Int(count)).map { pointer[$0] }
+    }
+}
+
+public extension Scancode {
+
+    /// Get a human-readable name for the scancode.
+    ///
+    /// - Returns: `nil` if the scancode doesn't have a name.
+    var name: String? {
+
+        let name = String(cString: SDL_GetScancodeName(SDL_Scancode(rawValue: rawValue)))
+        return name.isEmpty ? nil : name
+    }
+}
+
+// MARK: - Named Scancodes
+
+public extension Scancode {
+
+    static var a: Scancode { Scancode(rawValue: SDL_SCANCODE_A.rawValue) }
+    static var b: Scancode { Scancode(rawValue: SDL_SCANCODE_B.rawValue) }
+    static var c: Scancode { Scancode(rawValue: SDL_SCANCODE_C.rawValue) }
+    static var d: Scancode { Scancode(rawValue: SDL_SCANCODE_D.rawValue) }
+    static var e: Scancode { Scancode(rawValue: SDL_SCANCODE_E.rawValue) }
+    static var f: Scancode { Scancode(rawValue: SDL_SCANCODE_F.rawValue) }
+    static var g: Scancode { Scancode(rawValue: SDL_SCANCODE_G.rawValue) }
+    static var h: Scancode { Scancode(rawValue: SDL_SCANCODE_H.rawValue) }
+    static var i: Scancode { Scancode(rawValue: SDL_SCANCODE_I.rawValue) }
+    static var j: Scancode { Scancode(rawValue: SDL_SCANCODE_J.rawValue) }
+    static var k: Scancode { Scancode(rawValue: SDL_SCANCODE_K.rawValue) }
+    static var l: Scancode { Scancode(rawValue: SDL_SCANCODE_L.rawValue) }
+    static var m: Scancode { Scancode(rawValue: SDL_SCANCODE_M.rawValue) }
+    static var n: Scancode { Scancode(rawValue: SDL_SCANCODE_N.rawValue) }
+    static var o: Scancode { Scancode(rawValue: SDL_SCANCODE_O.rawValue) }
+    static var p: Scancode { Scancode(rawValue: SDL_SCANCODE_P.rawValue) }
+    static var q: Scancode { Scancode(rawValue: SDL_SCANCODE_Q.rawValue) }
+    static var r: Scancode { Scancode(rawValue: SDL_SCANCODE_R.rawValue) }
+    static var s: Scancode { Scancode(rawValue: SDL_SCANCODE_S.rawValue) }
+    static var t: Scancode { Scancode(rawValue: SDL_SCANCODE_T.rawValue) }
+    static var u: Scancode { Scancode(rawValue: SDL_SCANCODE_U.rawValue) }
+    static var v: Scancode { Scancode(rawValue: SDL_SCANCODE_V.rawValue) }
+    static var w: Scancode { Scancode(rawValue: SDL_SCANCODE_W.rawValue) }
+    static var x: Scancode { Scancode(rawValue: SDL_SCANCODE_X.rawValue) }
+    static var y: Scancode { Scancode(rawValue: SDL_SCANCODE_Y.rawValue) }
+    static var z: Scancode { Scancode(rawValue: SDL_SCANCODE_Z.rawValue) }
+
+    static var escape: Scancode { Scancode(rawValue: SDL_SCANCODE_ESCAPE.rawValue) }
+    static var `return`: Scancode { Scancode(rawValue: SDL_SCANCODE_RETURN.rawValue) }
+    static var space: Scancode { Scancode(rawValue: SDL_SCANCODE_SPACE.rawValue) }
+    static var tab: Scancode { Scancode(rawValue: SDL_SCANCODE_TAB.rawValue) }
+
+    static var up: Scancode { Scancode(rawValue: SDL_SCANCODE_UP.rawValue) }
+    static var down: Scancode { Scancode(rawValue: SDL_SCANCODE_DOWN.rawValue) }
+    static var left: Scancode { Scancode(rawValue: SDL_SCANCODE_LEFT.rawValue) }
+    static var right: Scancode { Scancode(rawValue: SDL_SCANCODE_RIGHT.rawValue) }
+
+    static var f8: Scancode { Scancode(rawValue: SDL_SCANCODE_F8.rawValue) }
+    static var f9: Scancode { Scancode(rawValue: SDL_SCANCODE_F9.rawValue) }
+    static var f10: Scancode { Scancode(rawValue: SDL_SCANCODE_F10.rawValue) }
+
+    static var minus: Scancode { Scancode(rawValue: SDL_SCANCODE_MINUS.rawValue) }
+    static var equals: Scancode { Scancode(rawValue: SDL_SCANCODE_EQUALS.rawValue) }
+    static var leftBracket: Scancode { Scancode(rawValue: SDL_SCANCODE_LEFTBRACKET.rawValue) }
+    static var rightBracket: Scancode { Scancode(rawValue: SDL_SCANCODE_RIGHTBRACKET.rawValue) }
+    static var backslash: Scancode { Scancode(rawValue: SDL_SCANCODE_BACKSLASH.rawValue) }
+    static var semicolon: Scancode { Scancode(rawValue: SDL_SCANCODE_SEMICOLON.rawValue) }
+    static var apostrophe: Scancode { Scancode(rawValue: SDL_SCANCODE_APOSTROPHE.rawValue) }
+    static var grave: Scancode { Scancode(rawValue: SDL_SCANCODE_GRAVE.rawValue) }
+
+    static var keypadDivide: Scancode { Scancode(rawValue: SDL_SCANCODE_KP_DIVIDE.rawValue) }
+    static var keypadMultiply: Scancode { Scancode(rawValue: SDL_SCANCODE_KP_MULTIPLY.rawValue) }
+    static var keypadMinus: Scancode { Scancode(rawValue: SDL_SCANCODE_KP_MINUS.rawValue) }
+    static var keypadPlus: Scancode { Scancode(rawValue: SDL_SCANCODE_KP_PLUS.rawValue) }
+    static var keypadEnter: Scancode { Scancode(rawValue: SDL_SCANCODE_KP_ENTER.rawValue) }
+    static var keypadPeriod: Scancode { Scancode(rawValue: SDL_SCANCODE_KP_PERIOD.rawValue) }
+
+    static var leftAlt: Scancode { Scancode(rawValue: SDL_SCANCODE_LALT.rawValue) }
+    static var rightAlt: Scancode { Scancode(rawValue: SDL_SCANCODE_RALT.rawValue) }
+    static var leftGUI: Scancode { Scancode(rawValue: SDL_SCANCODE_LGUI.rawValue) }
+    static var rightGUI: Scancode { Scancode(rawValue: SDL_SCANCODE_RGUI.rawValue) }
+    static var leftControl: Scancode { Scancode(rawValue: SDL_SCANCODE_LCTRL.rawValue) }
+    static var rightControl: Scancode { Scancode(rawValue: SDL_SCANCODE_RCTRL.rawValue) }
+    static var leftShift: Scancode { Scancode(rawValue: SDL_SCANCODE_LSHIFT.rawValue) }
+    static var rightShift: Scancode { Scancode(rawValue: SDL_SCANCODE_RSHIFT.rawValue) }
+}

--- a/Sources/SDL3/Log.swift
+++ b/Sources/SDL3/Log.swift
@@ -1,0 +1,63 @@
+//
+//  Log.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+public extension SDL {
+
+    /// Log a message with the given category and priority.
+    ///
+    /// - Note: SDL's variadic logging functions (`SDL_Log`, `SDL_LogError`, ...) aren't callable
+    ///   from Swift, so this routes through `SDL_LogMessageV` with a fixed `"%s"` format string.
+    static func log(_ message: String, category: LogCategory = .application, priority: LogPriority = .info) {
+
+        message.withCString { cString in
+            withVaList([cString]) { arguments in
+                SDL_LogMessageV(category.rawValue, priority.sdlValue, "%s", arguments)
+            }
+        }
+    }
+
+    /// Set the priority of all log categories.
+    static func setLogPriorities(_ priority: LogPriority) {
+        SDL_SetLogPriorities(priority.sdlValue)
+    }
+}
+
+// MARK: - Supporting Types
+
+/// A category of a log message.
+public struct LogCategory: RawRepresentable, Equatable, Hashable, Sendable {
+
+    public let rawValue: Int32
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    public static var application: LogCategory { LogCategory(rawValue: Int32(SDL_LOG_CATEGORY_APPLICATION.rawValue)) }
+}
+
+/// The priority of a log message.
+public struct LogPriority: RawRepresentable, Equatable, Hashable, Sendable {
+
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    internal var sdlValue: SDL_LogPriority {
+        SDL_LogPriority(rawValue: rawValue)
+    }
+
+    public static var verbose: LogPriority { LogPriority(rawValue: SDL_LOG_PRIORITY_VERBOSE.rawValue) }
+    public static var info: LogPriority { LogPriority(rawValue: SDL_LOG_PRIORITY_INFO.rawValue) }
+    public static var warn: LogPriority { LogPriority(rawValue: SDL_LOG_PRIORITY_WARN.rawValue) }
+    public static var error: LogPriority { LogPriority(rawValue: SDL_LOG_PRIORITY_ERROR.rawValue) }
+    public static var critical: LogPriority { LogPriority(rawValue: SDL_LOG_PRIORITY_CRITICAL.rawValue) }
+}

--- a/Sources/SDL3/MessageBox.swift
+++ b/Sources/SDL3/MessageBox.swift
@@ -1,0 +1,33 @@
+//
+//  MessageBox.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+public extension SDL {
+
+    /// Display a simple modal message box.
+    static func showSimpleMessageBox(flags: MessageBoxFlags, title: String, message: String, window: SDLWindow? = nil) throws(SDLError) {
+
+        try SDL_ShowSimpleMessageBox(flags.rawValue, title, message, window?.internalPointer).sdlThrow(type: "SDL")
+    }
+}
+
+// MARK: - Supporting Types
+
+/// Flags for `SDL.showSimpleMessageBox(flags:title:message:window:)`.
+public struct MessageBoxFlags: OptionSet, Sendable {
+
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public static var error: MessageBoxFlags { MessageBoxFlags(rawValue: 0x00000010) }
+    public static var warning: MessageBoxFlags { MessageBoxFlags(rawValue: 0x00000020) }
+    public static var information: MessageBoxFlags { MessageBoxFlags(rawValue: 0x00000040) }
+}

--- a/Sources/SDL3/Mouse.swift
+++ b/Sources/SDL3/Mouse.swift
@@ -1,0 +1,68 @@
+//
+//  Mouse.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+public extension SDL {
+
+    /// The current state of the mouse, in window-relative coordinates.
+    static var mouseState: (buttons: MouseButtonFlags, x: Float, y: Float) {
+
+        var x: Float = 0
+        var y: Float = 0
+        let buttons = SDL_GetMouseState(&x, &y)
+        return (MouseButtonFlags(rawValue: buttons), x, y)
+    }
+
+    /// The current state of the mouse, relative to the last call (or since event initialization).
+    static var relativeMouseState: (buttons: MouseButtonFlags, x: Float, y: Float) {
+
+        var x: Float = 0
+        var y: Float = 0
+        let buttons = SDL_GetRelativeMouseState(&x, &y)
+        return (MouseButtonFlags(rawValue: buttons), x, y)
+    }
+}
+
+public extension SDLWindow {
+
+    /// Whether relative mouse mode is enabled for the window.
+    var relativeMouseMode: Bool {
+
+        get { SDL_GetWindowRelativeMouseMode(internalPointer) }
+    }
+
+    /// Set relative mouse mode for the window.
+    func setRelativeMouseMode(_ enabled: Bool) throws(SDLError) {
+
+        try SDL_SetWindowRelativeMouseMode(internalPointer, enabled).sdlThrow(type: "SDLWindow")
+    }
+
+    /// Set the window's mouse grab mode.
+    func setMouseGrab(_ grabbed: Bool) throws(SDLError) {
+
+        try SDL_SetWindowMouseGrab(internalPointer, grabbed).sdlThrow(type: "SDLWindow")
+    }
+}
+
+// MARK: - Supporting Types
+
+/// A bitmask of pressed mouse buttons, as reported by `SDL.mouseState`.
+public struct MouseButtonFlags: OptionSet, Sendable {
+
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public static var left: MouseButtonFlags { MouseButtonFlags(rawValue: 1 << (0)) }
+    public static var middle: MouseButtonFlags { MouseButtonFlags(rawValue: 1 << (1)) }
+    public static var right: MouseButtonFlags { MouseButtonFlags(rawValue: 1 << (2)) }
+    public static var x1: MouseButtonFlags { MouseButtonFlags(rawValue: 1 << (3)) }
+    public static var x2: MouseButtonFlags { MouseButtonFlags(rawValue: 1 << (4)) }
+}

--- a/Sources/SDL3/OpenGL.swift
+++ b/Sources/SDL3/OpenGL.swift
@@ -1,0 +1,129 @@
+//
+//  OpenGL.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+/// SDL OpenGL Context
+public final class SDLGLContext {
+
+    // MARK: - Properties
+
+    internal let internalPointer: SDL_GLContext
+
+    // MARK: - Initialization
+
+    deinit {
+        SDL_GL_DestroyContext(internalPointer)
+    }
+
+    /// Create an OpenGL context for use with an OpenGL window, and make it current.
+    public init(window: SDLWindow) throws(SDLError) {
+
+        let internalPointer = SDL_GL_CreateContext(window.internalPointer)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLGLContext")
+    }
+
+    // MARK: - Methods
+
+    /// Set up this OpenGL context for rendering into the given window.
+    public func makeCurrent(in window: SDLWindow) throws(SDLError) {
+
+        try SDL_GL_MakeCurrent(window.internalPointer, internalPointer).sdlThrow(type: "SDLGLContext")
+    }
+}
+
+// MARK: - SDLWindow
+
+public extension SDLWindow {
+
+    /// Update a window with OpenGL rendering.
+    func glSwap() throws(SDLError) {
+
+        try SDL_GL_SwapWindow(internalPointer).sdlThrow(type: "SDLWindow")
+    }
+}
+
+// MARK: - SDL
+
+public extension SDL {
+
+    /// Set an OpenGL window attribute before window creation.
+    static func glSetAttribute(_ attribute: GLAttribute, _ value: Int32) throws(SDLError) {
+
+        try SDL_GL_SetAttribute(attribute.sdlValue, value).sdlThrow(type: "SDL")
+    }
+
+    /// Get the actual value for an attribute from the current context.
+    static func glGetAttribute(_ attribute: GLAttribute) throws(SDLError) -> Int32 {
+
+        var value: Int32 = 0
+        try SDL_GL_GetAttribute(attribute.sdlValue, &value).sdlThrow(type: "SDL")
+        return value
+    }
+
+    /// Get an OpenGL function by name.
+    static func glProcAddress(_ name: String) -> SDL_FunctionPointer? {
+
+        SDL_GL_GetProcAddress(name)
+    }
+
+    /// The swap interval for the current OpenGL context.
+    static var glSwapInterval: Int32 {
+
+        get throws(SDLError) {
+            var interval: Int32 = 0
+            try SDL_GL_GetSwapInterval(&interval).sdlThrow(type: "SDL")
+            return interval
+        }
+    }
+
+    /// Set the swap interval for the current OpenGL context.
+    static func glSetSwapInterval(_ interval: Int32) throws(SDLError) {
+
+        try SDL_GL_SetSwapInterval(interval).sdlThrow(type: "SDL")
+    }
+}
+
+// MARK: - Supporting Types
+
+/// An OpenGL context attribute.
+public struct GLAttribute: RawRepresentable, Equatable, Hashable, Sendable {
+
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    internal var sdlValue: SDL_GLAttr {
+        SDL_GLAttr(rawValue: rawValue)
+    }
+
+    public static var contextProfileMask: GLAttribute { GLAttribute(rawValue: SDL_GL_CONTEXT_PROFILE_MASK.rawValue) }
+    public static var contextMajorVersion: GLAttribute { GLAttribute(rawValue: SDL_GL_CONTEXT_MAJOR_VERSION.rawValue) }
+    public static var contextMinorVersion: GLAttribute { GLAttribute(rawValue: SDL_GL_CONTEXT_MINOR_VERSION.rawValue) }
+    public static var multisampleBuffers: GLAttribute { GLAttribute(rawValue: SDL_GL_MULTISAMPLEBUFFERS.rawValue) }
+    public static var multisampleSamples: GLAttribute { GLAttribute(rawValue: SDL_GL_MULTISAMPLESAMPLES.rawValue) }
+    public static var shareWithCurrentContext: GLAttribute { GLAttribute(rawValue: SDL_GL_SHARE_WITH_CURRENT_CONTEXT.rawValue) }
+}
+
+public extension GLAttribute {
+
+    /// Values for the `contextProfileMask` attribute.
+    struct Profile: RawRepresentable, Equatable, Hashable, Sendable {
+
+        public let rawValue: Int32
+
+        public init(rawValue: Int32) {
+            self.rawValue = rawValue
+        }
+
+        public static var core: Profile { Profile(rawValue: Int32(SDL_GL_CONTEXT_PROFILE_CORE)) }
+        public static var compatibility: Profile { Profile(rawValue: Int32(SDL_GL_CONTEXT_PROFILE_COMPATIBILITY)) }
+        public static var es: Profile { Profile(rawValue: Int32(SDL_GL_CONTEXT_PROFILE_ES)) }
+    }
+}

--- a/Sources/SDL3/Properties.swift
+++ b/Sources/SDL3/Properties.swift
@@ -1,0 +1,26 @@
+//
+//  Properties.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+/// An SDL properties group identifier.
+public struct SDLProperties: RawRepresentable, Equatable, Hashable, Sendable {
+
+    public let rawValue: SDL_PropertiesID
+
+    public init(rawValue: SDL_PropertiesID) {
+        self.rawValue = rawValue
+    }
+}
+
+public extension SDLProperties {
+
+    /// Get a boolean property.
+    func boolean(_ name: String, default defaultValue: Bool = false) -> Bool {
+        SDL_GetBooleanProperty(rawValue, name, defaultValue)
+    }
+}

--- a/Sources/SDL3/Rect.swift
+++ b/Sources/SDL3/Rect.swift
@@ -1,0 +1,35 @@
+//
+//  Rect.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+/// A rectangle, with the origin at the upper left, in integer coordinates.
+public struct SDLRect: Equatable, Hashable, Sendable {
+
+    public var x: Int32
+    public var y: Int32
+    public var width: Int32
+    public var height: Int32
+
+    public init(x: Int32, y: Int32, width: Int32, height: Int32) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    internal init(_ internalValue: SDL_Rect) {
+        self.x = internalValue.x
+        self.y = internalValue.y
+        self.width = internalValue.w
+        self.height = internalValue.h
+    }
+
+    internal var internalValue: SDL_Rect {
+        SDL_Rect(x: x, y: y, w: width, h: height)
+    }
+}

--- a/Sources/SDL3/Time.swift
+++ b/Sources/SDL3/Time.swift
@@ -1,0 +1,59 @@
+//
+//  Time.swift
+//  SDL3
+//
+//  Created by Alsey Coleman Miller on 7/7/26.
+//
+
+import CSDL3
+
+public extension SDL {
+
+    /// The number of milliseconds since SDL library initialization.
+    static var ticksMilliseconds: UInt64 {
+        SDL_GetTicks()
+    }
+
+    /// Wait the specified number of milliseconds before returning.
+    static func delay(milliseconds: UInt32) {
+        SDL_Delay(milliseconds)
+    }
+
+    /// The current value of the system clock in nanoseconds since a platform-specific epoch.
+    static var currentTime: SDLDateTime? {
+
+        var ticks: SDL_Time = 0
+        guard SDL_GetCurrentTime(&ticks) else { return nil }
+        var dateTime = SDL_DateTime()
+        guard SDL_TimeToDateTime(ticks, &dateTime, true) else { return nil }
+        return SDLDateTime(dateTime)
+    }
+}
+
+// MARK: - Supporting Types
+
+/// A calendar date and time broken down into its components.
+public struct SDLDateTime: Equatable, Hashable, Sendable {
+
+    public var year: Int
+    public var month: Int
+    public var day: Int
+    public var hour: Int
+    public var minute: Int
+    public var second: Int
+    public var nanosecond: Int
+    public var dayOfWeek: Int
+    public var utcOffset: Int
+
+    internal init(_ internalValue: SDL_DateTime) {
+        self.year = Int(internalValue.year)
+        self.month = Int(internalValue.month)
+        self.day = Int(internalValue.day)
+        self.hour = Int(internalValue.hour)
+        self.minute = Int(internalValue.minute)
+        self.second = Int(internalValue.second)
+        self.nanosecond = Int(internalValue.nanosecond)
+        self.dayOfWeek = Int(internalValue.day_of_week)
+        self.utcOffset = Int(internalValue.utc_offset)
+    }
+}

--- a/Sources/SDL3/VideoDisplay.swift
+++ b/Sources/SDL3/VideoDisplay.swift
@@ -64,4 +64,42 @@ public extension SDLVideoDisplay {
 
         return (0 ..< Int(count)).compactMap { pointer[$0].map { SDLDisplayMode($0.pointee) } }
     }
+
+    /// The bounds of the display, in screen coordinates.
+    var bounds: SDLRect {
+
+        get throws(SDLError) {
+
+            var rect = SDL_Rect()
+            try SDL_GetDisplayBounds(rawValue, &rect).sdlThrow(type: "SDLVideoDisplay")
+            return SDLRect(rect)
+        }
+    }
+
+    /// The usable bounds of the display, in screen coordinates, excluding space taken up by menu bars, docks, etc.
+    var usableBounds: SDLRect {
+
+        get throws(SDLError) {
+
+            var rect = SDL_Rect()
+            try SDL_GetDisplayUsableBounds(rawValue, &rect).sdlThrow(type: "SDLVideoDisplay")
+            return SDLRect(rect)
+        }
+    }
+}
+
+public extension SDLWindow {
+
+    /// The display associated with this window.
+    var display: SDLVideoDisplay {
+        SDLVideoDisplay(rawValue: SDL_GetDisplayForWindow(internalPointer))
+    }
+}
+
+public extension SDL {
+
+    /// The name of the currently initialized video driver, or `nil` if video is not initialized.
+    static var currentVideoDriver: String? {
+        SDL_GetCurrentVideoDriver().map { String(cString: $0) }
+    }
 }

--- a/Sources/SDL3/Window.swift
+++ b/Sources/SDL3/Window.swift
@@ -130,6 +130,32 @@ public final class SDLWindow: Identifiable {
 
         }
     }
+
+    /// Set the window's fullscreen state.
+    ///
+    /// - Note: This is distinct from ``setDisplayMode(_:)``, which sets the mode used while fullscreen.
+    public func setFullscreen(_ fullscreen: Bool) throws(SDLError) {
+
+        try SDL_SetWindowFullscreen(internalPointer, fullscreen).sdlThrow(type: "SDLWindow")
+    }
+
+    /// The position of the window, in screen coordinates.
+    public var position: (x: Int32, y: Int32) {
+
+        get throws(SDLError) {
+
+            var x: Int32 = 0
+            var y: Int32 = 0
+            try SDL_GetWindowPosition(internalPointer, &x, &y).sdlThrow(type: "SDLWindow")
+            return (x, y)
+        }
+    }
+
+    /// Block until any pending window state is applied.
+    public func sync() throws(SDLError) {
+
+        try SDL_SyncWindow(internalPointer).sdlThrow(type: "SDLWindow")
+    }
 }
 
 // MARK: - Supporting Types


### PR DESCRIPTION
## Summary
- Adds `OpenGL.swift` wrapping SDL3's GL context management (`SDL_GL_CreateContext`/`MakeCurrent`/`SwapWindow`/attributes/swap interval), previously uncovered.
- Adds `Keyboard.swift` and `Mouse.swift` for polled input state (`SDL_GetKeyboardState`, `SDL_GetMouseState`, relative mouse mode, mouse grab).
- Adds `Time.swift`, `Log.swift`, `MessageBox.swift`, `Rect.swift`, `Properties.swift`, `Joystick.swift`.
- Extends `Gamepad.swift` (name, rumble, player index, mapping files), `Window.swift` (fullscreen, position, sync), `VideoDisplay.swift` (bounds, usable bounds, per-window display, current video driver), and `Event.swift` (mouse wheel, text input, window close requested).

## Test plan
- [x] `swift build` (whole package) succeeds
- [x] `swift test --filter SDL3Tests` passes
- [x] Manual runtime smoke test: GL context creation/make-current/swap, keyboard state + scancode names, mouse state, ticks, logging, display bounds, video driver, window position/fullscreen/sync, joystick enumeration all verified working against the local SDL3 install