### PR TITLE
Add SDL 1.2 wrappers

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Swift Version
       run: swift --version
     - name: Install dependencies
-      run: brew install sdl2 sdl3 sdl2_image sdl2_mixer sdl3_image sdl3_mixer
+      run: brew install sdl12-compat sdl2 sdl3 sdl2_image sdl2_mixer sdl3_image sdl3_mixer
     - name: Build
       run: swift build -c ${{ matrix.config }}
 
@@ -34,7 +34,7 @@ jobs:
       run: swift --version
     - name: Install dependencies
       run: |
-        apt-get update && apt-get install -y libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
+        apt-get update && apt-get install -y libsdl1.2-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
         cmake ninja-build pkg-config \
         libasound2-dev libpulse-dev libaudio-dev libfribidi-dev libjack-dev libsndio-dev \
         libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,10 @@ let package = Package(
     name: "SDL",
     products: [
         .library(
+            name: "SDL1Swift",
+            targets: ["SDL1Swift"]
+        ),
+        .library(
             name: "SDL2Swift",
             targets: ["SDL2Swift"]
         ),
@@ -53,6 +57,21 @@ let package = Package(
         .executableTarget(
             name: "SDLDemo",
             dependencies: ["SDL2Swift"]
+        ),
+        // Named `SDL1Swift` (not `SDL1`) so the built module doesn't share a name
+        // with the `SDL` system library, which would shadow `-lSDL` when linking.
+        .target(
+            name: "SDL1Swift",
+            dependencies: ["CSDL"],
+            path: "Sources/SDL1"
+        ),
+        .systemLibrary(
+            name: "CSDL",
+            pkgConfig: "sdl",
+            providers: [
+                .brew(["sdl12-compat"]),
+                .apt(["libsdl1.2-compat-dev"])
+            ]
         ),
         // Named `SDL2Swift` (not `SDL2`) so the built module doesn't share a name
         // with the `SDL2` system library, which would shadow `-lSDL2` when linking.
@@ -137,6 +156,9 @@ let package = Package(
                 .apt(["libsdl3-mixer-dev"])
             ]
         ),
+        .testTarget(
+            name: "SDL1Tests",
+            dependencies: ["SDL1Swift"]),
         .testTarget(
             name: "SDL2Tests",
             dependencies: ["SDL2Swift"]),

--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,7 @@ let package = Package(
             pkgConfig: "sdl",
             providers: [
                 .brew(["sdl12-compat"]),
-                .apt(["libsdl1.2-compat-dev"])
+                .apt(["libsdl1.2-dev"])
             ]
         ),
         // Named `SDL2Swift` (not `SDL2`) so the built module doesn't share a name

--- a/Sources/CSDL/module.modulemap
+++ b/Sources/CSDL/module.modulemap
@@ -1,0 +1,5 @@
+module CSDL [system] {
+    header "shim.h"
+    link "SDL"
+    export *
+}

--- a/Sources/CSDL/shim.h
+++ b/Sources/CSDL/shim.h
@@ -1,0 +1,5 @@
+#ifdef __APPLE__
+#include "/opt/homebrew/include/SDL/SDL.h"
+#else
+#include <SDL/SDL.h>
+#endif

--- a/Sources/SDL1/BitMaskOption.swift
+++ b/Sources/SDL1/BitMaskOption.swift
@@ -1,0 +1,194 @@
+//
+//  BitMaskOption.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 6/6/17.
+//
+
+/// Enum that represents a bit mask flag / option.
+///
+/// Basically `Swift.OptionSet` for enums.
+public protocol BitMaskOption: RawRepresentable, Hashable, CaseIterable where RawValue: FixedWidthInteger { }
+
+public extension Sequence where Element: BitMaskOption {
+
+    /// Convert Swift enums for bit mask options into their raw values OR'd.
+    var rawValue: Element.RawValue {
+
+        @inline(__always)
+        get { return reduce(0, { $0 | $1.rawValue }) }
+    }
+}
+
+public extension BitMaskOption {
+
+    /// Whether the enum case is present in the raw value.
+    @inline(__always)
+    func isContained(in rawValue: RawValue) -> Bool {
+
+        return (self.rawValue & rawValue) != 0
+    }
+
+    @inline(__always)
+    static func from(rawValue: RawValue) -> [Self] {
+
+        return Self.allCases.filter { $0.isContained(in: rawValue) }
+    }
+}
+
+// MARK: - BitMaskOptionSet
+
+/// Integer-backed array type for `BitMaskOption`.
+///
+/// The elements are packed in the integer with bitwise math and stored on the stack.
+public struct BitMaskOptionSet <Element: BitMaskOption>: RawRepresentable {
+
+    public typealias RawValue = Element.RawValue
+
+    public private(set) var rawValue: RawValue
+
+    @inline(__always)
+    public init(rawValue: RawValue) {
+
+        self.rawValue = rawValue
+    }
+
+    @inline(__always)
+    public init() {
+
+        self.rawValue = 0
+    }
+
+    public static var all: BitMaskOptionSet<Element> {
+
+        return BitMaskOptionSet<Element>(rawValue: Element.allCases.rawValue)
+    }
+
+    @inline(__always)
+    public mutating func insert(_ element: Element) {
+
+        rawValue = rawValue | element.rawValue
+    }
+
+    @discardableResult
+    public mutating func remove(_ element: Element) -> Bool {
+
+        guard contains(element) else { return false }
+
+        rawValue = rawValue & ~element.rawValue
+
+        return true
+    }
+
+    @inline(__always)
+    public mutating func removeAll() {
+
+        self.rawValue = 0
+    }
+
+    @inline(__always)
+    public func contains(_ element: Element) -> Bool {
+
+        return element.isContained(in: rawValue)
+    }
+
+    public func contains <S: Sequence> (_ other: S) -> Bool where S.Iterator.Element == Element {
+
+        for element in other {
+
+            guard element.isContained(in: rawValue)
+                else { return false }
+        }
+
+        return true
+    }
+
+    public var count: Int {
+
+        return Element.allCases.reduce(0, { $0 + ($1.isContained(in: rawValue) ? 1 : 0) })
+    }
+
+    public var isEmpty: Bool {
+
+        return rawValue == 0
+    }
+}
+
+// MARK: - Sequence Conversion
+
+public extension BitMaskOptionSet {
+
+    init<S: Sequence>(_ sequence: S) where S.Iterator.Element == Element {
+
+        self.rawValue = sequence.rawValue
+    }
+}
+
+// MARK: - Equatable
+
+extension BitMaskOptionSet: Equatable {
+
+    public static func == (lhs: BitMaskOptionSet, rhs: BitMaskOptionSet) -> Bool {
+
+        return lhs.rawValue == rhs.rawValue
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension BitMaskOptionSet: CustomStringConvertible {
+
+    public var description: String {
+
+        return Element.from(rawValue: rawValue)
+            .sorted(by: { $0.rawValue < $1.rawValue })
+            .description
+    }
+}
+
+// MARK: - Hashable
+
+extension BitMaskOptionSet: Hashable {
+
+    #if swift(>=4.2)
+    public func hash(into hasher: inout Hasher) {
+
+        rawValue.hash(into: &hasher)
+    }
+    #else
+    public var hashValue: Int {
+
+        return rawValue.hashValue
+    }
+    #endif
+}
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension BitMaskOptionSet: ExpressibleByArrayLiteral {
+
+    public init(arrayLiteral elements: Element...) {
+
+        self.init(elements)
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension BitMaskOptionSet: ExpressibleByIntegerLiteral {
+
+    public init(integerLiteral value: UInt64) {
+
+        self.init(rawValue: numericCast(value))
+    }
+}
+
+// MARK: - Sequence
+
+extension BitMaskOptionSet: Sequence {
+
+    public func makeIterator() -> IndexingIterator<[Element]> {
+
+        return Element.from(rawValue: rawValue).makeIterator()
+    }
+}

--- a/Sources/SDL1/Color.swift
+++ b/Sources/SDL1/Color.swift
@@ -1,0 +1,36 @@
+//
+//  Color.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL Color
+///
+/// A single color entry, as used by palettes. SDL 1.2 colors carry no alpha channel.
+public struct SDLColor: Equatable, Hashable, Sendable {
+
+    public var red: UInt8
+
+    public var green: UInt8
+
+    public var blue: UInt8
+
+    public init(red: UInt8, green: UInt8, blue: UInt8) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
+
+    internal init(_ color: SDL_Color) {
+        self.red = color.r
+        self.green = color.g
+        self.blue = color.b
+    }
+
+    internal var internalValue: SDL_Color {
+        SDL_Color(r: red, g: green, b: blue, unused: 0)
+    }
+}

--- a/Sources/SDL1/CountableSet.swift
+++ b/Sources/SDL1/CountableSet.swift
@@ -1,0 +1,63 @@
+//
+//  CountableSet.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 10/19/18.
+//
+
+/// Static Integer-based array for use on the stack.
+///
+/// Allows a count value to be used a collection.
+/// Each element is basically a valid index in the collection (e.g. `0 ..< count`).
+public struct CountableSet <Element: IndexRepresentable>: Collection {
+
+    public typealias Index = Int
+
+    public init(count: Int) {
+
+        precondition(count >= 0, "Invalid negative value \(count)")
+
+        self.count = count
+    }
+
+    public var count: Int
+
+    public subscript (index: Index) -> Element {
+
+        assert(index < count, "Invalid index")
+
+        return Element(rawValue: index)
+    }
+
+    /// The start `Index`.
+    public var startIndex: Index {
+        return 0
+    }
+
+    /// The end `Index`.
+    ///
+    /// This is the "one-past-the-end" position, and will always be equal to the `count`.
+    public var endIndex: Index {
+        return count
+    }
+
+    public func index(before i: Index) -> Index {
+        return i - 1
+    }
+
+    public func index(after i: Index) -> Index {
+        return i + 1
+    }
+
+    public func makeIterator() -> IndexingIterator<CountableSet<Element>> {
+        return IndexingIterator(_elements: self)
+    }
+}
+
+/// A struct wrapper that represents an index value.
+public protocol IndexRepresentable: RawRepresentable, Hashable {
+
+    init(rawValue: Int)
+
+    var rawValue: Int { get }
+}

--- a/Sources/SDL1/Cursor.swift
+++ b/Sources/SDL1/Cursor.swift
@@ -1,0 +1,67 @@
+//
+//  Cursor.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL Cursor
+public final class SDLCursor {
+
+    // MARK: - Properties
+
+    internal let internalPointer: UnsafeMutablePointer<SDL_Cursor>
+
+    internal let owned: Bool
+
+    // MARK: - Initialization
+
+    deinit {
+        if owned {
+            SDL_FreeCursor(internalPointer)
+        }
+    }
+
+    internal init(internalPointer: UnsafeMutablePointer<SDL_Cursor>, owned: Bool) {
+        self.internalPointer = internalPointer
+        self.owned = owned
+    }
+
+    /// Create a cursor from monochrome data and mask bitmaps.
+    ///
+    /// - Parameters:
+    ///   - data: The cursor bitmap; each bit is a pixel (1 = black, 0 = white when the mask bit is set).
+    ///   - mask: The transparency mask; each bit set marks the pixel as opaque.
+    ///   - size: The width and height of the cursor in pixels. Width must be a multiple of 8.
+    ///   - hotspot: The position of the cursor hotspot, relative to the top-left.
+    public init(
+        data: [UInt8],
+        mask: [UInt8],
+        size: (width: Int, height: Int),
+        hotspot: (x: Int, y: Int)
+    ) throws(SDLError) {
+
+        var data = data
+        var mask = mask
+        let internalPointer = SDL_CreateCursor(&data, &mask, CInt(size.width), CInt(size.height), CInt(hotspot.x), CInt(hotspot.y))
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLCursor")
+        self.owned = true
+    }
+
+    // MARK: - Accessors
+
+    /// The currently active cursor.
+    public static var current: SDLCursor? {
+        guard let internalPointer = SDL_GetCursor() else { return nil }
+        return SDLCursor(internalPointer: internalPointer, owned: false)
+    }
+
+    // MARK: - Methods
+
+    /// Set this cursor as the active cursor.
+    public func set() {
+        SDL_SetCursor(internalPointer)
+    }
+}

--- a/Sources/SDL1/Error.swift
+++ b/Sources/SDL1/Error.swift
@@ -1,0 +1,128 @@
+//
+//  Error.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 10/19/18.
+//
+
+import CSDL
+
+/// SDL Error
+public struct SDLError: Error {
+
+    public let errorMessage: String
+
+    public let context: Context?
+
+    public init(errorMessage: String, context: Context? = nil) {
+        self.errorMessage = errorMessage
+        self.context = context
+    }
+}
+
+extension SDLError: CustomStringConvertible {
+
+    public var description: String {
+        return errorMessage
+    }
+}
+
+extension SDLError: CustomDebugStringConvertible {
+
+    public var debugDescription: String {
+
+        var description = errorMessage
+        if let context {
+            description += " " + "(\(context.description))"
+        }
+        return description
+    }
+}
+
+public extension SDLError {
+
+    struct Context: CustomStringConvertible, Sendable {
+
+        public let file: String
+
+        public let type: String
+
+        public let function: String
+
+        public let line: UInt
+
+        public init(file: String,
+                      type: StaticString,
+                      function: String,
+                      line: UInt) {
+
+            self.file = file
+            self.function = function
+            self.line = line
+            self.type = type.description
+        }
+
+        public var description: String {
+            let fileName = file.split(separator: "/").last.flatMap { String($0) } ?? file
+            return "\(fileName):\(line.description) \(type).\(function)"
+        }
+    }
+}
+
+public extension SDLError {
+
+    /// Text for last reported error.
+    static func current(context: Context? = nil) -> SDLError? {
+
+        guard let cString = SDL_GetError(), cString.pointee != 0
+            else { return nil }
+
+        let errorDescription = String(cString: cString)
+        SDL_ClearError() // reset error
+
+        return SDLError(errorMessage: errorDescription, context: context)
+    }
+}
+
+public extension CInt {
+
+    /// Throws for error codes.
+    @inline(__always)
+    func sdlThrow(
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line,
+        type: StaticString
+    ) throws(SDLError) {
+
+        guard self >= 0 else {
+            let context = SDLError.Context(file: file, type: type, function: function, line: line)
+            guard let error = SDLError.current(context: context) else {
+                assertionFailure("No error for error code \(self)")
+                throw SDLError(errorMessage: "Error code \(self)", context: context)
+            }
+            throw error
+        }
+    }
+}
+
+public extension Optional {
+
+    /// Unwraps optional value, throwing error if nil.
+    @inline(__always)
+    func sdlThrow(file: String = #file,
+                  function: String = #function,
+                  line: UInt = #line,
+                  type: StaticString) throws(SDLError) -> Wrapped {
+
+        guard let value = self else {
+            let context = SDLError.Context(file: file, type: type, function: function, line: line)
+            guard let error = SDLError.current(context: context) else {
+                assertionFailure("No error for nil value")
+                throw SDLError(errorMessage: "Nil value (" + type.description + ")", context: context)
+            }
+            throw error
+        }
+        return value
+    }
+}

--- a/Sources/SDL1/Event.swift
+++ b/Sources/SDL1/Event.swift
@@ -1,0 +1,110 @@
+//
+//  Event.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+public extension SDL {
+
+    /// Poll for currently pending events.
+    ///
+    /// - Returns: The next event in the queue, or `nil` if the queue is empty.
+    static func pollEvent() -> SDLEvent? {
+
+        var event = SDL_Event()
+        guard SDL_PollEvent(&event) != 0 else { return nil }
+        return SDLEvent(event)
+    }
+
+    /// Wait indefinitely for the next available event.
+    ///
+    /// - Returns: The next event, or `nil` if an error occurred while waiting.
+    static func waitEvent() -> SDLEvent? {
+
+        var event = SDL_Event()
+        guard SDL_WaitEvent(&event) != 0 else { return nil }
+        return SDLEvent(event)
+    }
+}
+
+/// A polled SDL event.
+public enum SDLEvent {
+
+    case quit
+    case active(gained: Bool, state: UInt8)
+    case keyDown(key: SDLKeycode, scancode: UInt8, modifiers: BitMaskOptionSet<SDLKeyModifier>, unicode: UInt16)
+    case keyUp(key: SDLKeycode, scancode: UInt8, modifiers: BitMaskOptionSet<SDLKeyModifier>, unicode: UInt16)
+    case mouseMotion(x: UInt16, y: UInt16, relativeX: Int16, relativeY: Int16, state: UInt8)
+    case mouseButtonDown(x: UInt16, y: UInt16, button: SDLMouseButton)
+    case mouseButtonUp(x: UInt16, y: UInt16, button: SDLMouseButton)
+    case joyAxisMotion(joystick: UInt8, axis: UInt8, value: Int16)
+    case joyButtonDown(joystick: UInt8, button: UInt8)
+    case joyButtonUp(joystick: UInt8, button: UInt8)
+    case joyHatMotion(joystick: UInt8, hat: UInt8, value: UInt8)
+    case videoResize(width: Int, height: Int)
+    case videoExpose
+
+    /// An event that isn't yet modeled by `SDLEvent`. The raw `SDL_EventType` value is preserved.
+    case unknown(UInt8)
+
+    internal init(_ event: SDL_Event) {
+
+        switch SDL_EventType(rawValue: UInt32(event.type)) {
+
+        case SDL_QUIT:
+            self = .quit
+
+        case SDL_ACTIVEEVENT:
+            self = .active(gained: event.active.gain != 0, state: event.active.state)
+
+        case SDL_KEYDOWN:
+            self = .keyDown(
+                key: SDLKeycode(event.key.keysym.sym),
+                scancode: event.key.keysym.scancode,
+                modifiers: BitMaskOptionSet<SDLKeyModifier>(rawValue: numericCast(event.key.keysym.mod.rawValue)),
+                unicode: event.key.keysym.unicode
+            )
+
+        case SDL_KEYUP:
+            self = .keyUp(
+                key: SDLKeycode(event.key.keysym.sym),
+                scancode: event.key.keysym.scancode,
+                modifiers: BitMaskOptionSet<SDLKeyModifier>(rawValue: numericCast(event.key.keysym.mod.rawValue)),
+                unicode: event.key.keysym.unicode
+            )
+
+        case SDL_MOUSEMOTION:
+            self = .mouseMotion(x: event.motion.x, y: event.motion.y, relativeX: event.motion.xrel, relativeY: event.motion.yrel, state: event.motion.state)
+
+        case SDL_MOUSEBUTTONDOWN:
+            self = .mouseButtonDown(x: event.button.x, y: event.button.y, button: SDLMouseButton(rawValue: event.button.button))
+
+        case SDL_MOUSEBUTTONUP:
+            self = .mouseButtonUp(x: event.button.x, y: event.button.y, button: SDLMouseButton(rawValue: event.button.button))
+
+        case SDL_JOYAXISMOTION:
+            self = .joyAxisMotion(joystick: event.jaxis.which, axis: event.jaxis.axis, value: event.jaxis.value)
+
+        case SDL_JOYBUTTONDOWN:
+            self = .joyButtonDown(joystick: event.jbutton.which, button: event.jbutton.button)
+
+        case SDL_JOYBUTTONUP:
+            self = .joyButtonUp(joystick: event.jbutton.which, button: event.jbutton.button)
+
+        case SDL_JOYHATMOTION:
+            self = .joyHatMotion(joystick: event.jhat.which, hat: event.jhat.hat, value: event.jhat.value)
+
+        case SDL_VIDEORESIZE:
+            self = .videoResize(width: Int(event.resize.w), height: Int(event.resize.h))
+
+        case SDL_VIDEOEXPOSE:
+            self = .videoExpose
+
+        default:
+            self = .unknown(event.type)
+        }
+    }
+}

--- a/Sources/SDL1/Joystick.swift
+++ b/Sources/SDL1/Joystick.swift
@@ -1,0 +1,106 @@
+//
+//  Joystick.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL Joystick
+public final class SDLJoystick {
+
+    // MARK: - Properties
+
+    internal let internalPointer: OpaquePointer
+
+    // MARK: - Initialization
+
+    deinit {
+        SDL_JoystickClose(internalPointer)
+    }
+
+    /// Open a joystick for use by its device index.
+    public init(index: Int) throws(SDLError) {
+        let internalPointer = SDL_JoystickOpen(CInt(index))
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLJoystick")
+    }
+
+    // MARK: - Static Accessors
+
+    /// The number of joysticks attached to the system.
+    public static var count: Int {
+        return Int(SDL_NumJoysticks())
+    }
+
+    /// The implementation-dependent name of the joystick at the given device index.
+    public static func name(for index: Int) -> String? {
+        guard let cString = SDL_JoystickName(CInt(index)) else { return nil }
+        return String(cString: cString)
+    }
+
+    /// Update the state of all open joysticks.
+    ///
+    /// Not needed if joystick events are enabled.
+    public static func update() {
+        SDL_JoystickUpdate()
+    }
+
+    /// Enable or disable joystick event polling.
+    @discardableResult
+    public static func setEventState(_ enabled: Bool) -> Bool {
+        return SDL_JoystickEventState(enabled ? 1 : 0) == 1
+    }
+
+    // MARK: - Accessors
+
+    /// The device index of this joystick.
+    public var index: Int {
+        return Int(SDL_JoystickIndex(internalPointer))
+    }
+
+    /// The number of general axis controls on the joystick.
+    public var numberOfAxes: Int {
+        return Int(SDL_JoystickNumAxes(internalPointer))
+    }
+
+    /// The number of trackballs on the joystick.
+    public var numberOfBalls: Int {
+        return Int(SDL_JoystickNumBalls(internalPointer))
+    }
+
+    /// The number of POV hats on the joystick.
+    public var numberOfHats: Int {
+        return Int(SDL_JoystickNumHats(internalPointer))
+    }
+
+    /// The number of buttons on the joystick.
+    public var numberOfButtons: Int {
+        return Int(SDL_JoystickNumButtons(internalPointer))
+    }
+
+    // MARK: - Methods
+
+    /// The current value of the given axis, in the range `-32768` to `32767`.
+    public func axis(_ axis: Int) -> Int16 {
+        return SDL_JoystickGetAxis(internalPointer, CInt(axis))
+    }
+
+    /// Whether the given button is currently pressed.
+    public func button(_ button: Int) -> Bool {
+        return SDL_JoystickGetButton(internalPointer, CInt(button)) != 0
+    }
+
+    /// The current position of the given POV hat.
+    public func hat(_ hat: Int) -> UInt8 {
+        return SDL_JoystickGetHat(internalPointer, CInt(hat))
+    }
+
+    /// The relative movement of the given trackball since the last query.
+    public func ball(_ ball: Int) -> (dx: Int, dy: Int)? {
+        var dx: CInt = 0
+        var dy: CInt = 0
+        guard SDL_JoystickGetBall(internalPointer, CInt(ball), &dx, &dy) == 0 else { return nil }
+        return (Int(dx), Int(dy))
+    }
+}

--- a/Sources/SDL1/Keyboard.swift
+++ b/Sources/SDL1/Keyboard.swift
@@ -1,0 +1,96 @@
+//
+//  Keyboard.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+public extension SDL {
+
+    /// Get a snapshot of the current state of the keyboard.
+    ///
+    /// - Returns: An array indexed by `SDLKeycode.rawValue`; `true` means the key is pressed.
+    static func keyboardState() -> [Bool] {
+        var count: CInt = 0
+        guard let pointer = SDL_GetKeyState(&count), count > 0 else { return [] }
+        return (0 ..< Int(count)).map { pointer[$0] != 0 }
+    }
+
+    /// The current state of the keyboard modifier keys.
+    static var modifierState: BitMaskOptionSet<SDLKeyModifier> {
+        get { BitMaskOptionSet<SDLKeyModifier>(rawValue: numericCast(SDL_GetModState().rawValue)) }
+        set { SDL_SetModState(SDLMod(rawValue: numericCast(newValue.rawValue))) }
+    }
+
+    /// Enable keyboard repeat, or pass `nil` to disable it.
+    static func enableKeyRepeat(delay: Int = Int(SDL_DEFAULT_REPEAT_DELAY), interval: Int = Int(SDL_DEFAULT_REPEAT_INTERVAL)) throws(SDLError) {
+        try SDL_EnableKeyRepeat(CInt(delay), CInt(interval)).sdlThrow(type: "SDL")
+    }
+
+    /// Enable or disable Unicode translation of keyboard input.
+    ///
+    /// - Returns: The previous enabled state.
+    @discardableResult
+    static func enableUnicode(_ enabled: Bool) -> Bool {
+        return SDL_EnableUNICODE(enabled ? 1 : 0) != 0
+    }
+}
+
+// MARK: - Supporting Types
+
+/// A virtual keyboard key symbol.
+public struct SDLKeycode: RawRepresentable, Equatable, Hashable, Sendable {
+
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    internal init(_ key: SDLKey) {
+        self.rawValue = numericCast(key.rawValue)
+    }
+
+    /// The human readable name of the key.
+    public var name: String {
+        return String(cString: SDL_GetKeyName(SDLKey(numericCast(rawValue))))
+    }
+}
+
+public extension SDLKeycode {
+
+    static var backspace: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_BACKSPACE.rawValue)) }
+    static var tab: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_TAB.rawValue)) }
+    static var `return`: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_RETURN.rawValue)) }
+    static var escape: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_ESCAPE.rawValue)) }
+    static var space: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_SPACE.rawValue)) }
+    static var delete: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_DELETE.rawValue)) }
+
+    static var up: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_UP.rawValue)) }
+    static var down: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_DOWN.rawValue)) }
+    static var left: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_LEFT.rawValue)) }
+    static var right: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_RIGHT.rawValue)) }
+
+    static var leftShift: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_LSHIFT.rawValue)) }
+    static var rightShift: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_RSHIFT.rawValue)) }
+    static var leftControl: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_LCTRL.rawValue)) }
+    static var rightControl: SDLKeycode { SDLKeycode(rawValue: numericCast(SDLK_RCTRL.rawValue)) }
+}
+
+/// A keyboard modifier key.
+public enum SDLKeyModifier: UInt32, BitMaskOption {
+
+    case leftShift = 0x0001
+    case rightShift = 0x0002
+    case leftControl = 0x0040
+    case rightControl = 0x0080
+    case leftAlt = 0x0100
+    case rightAlt = 0x0200
+    case leftMeta = 0x0400
+    case rightMeta = 0x0800
+    case numLock = 0x1000
+    case capsLock = 0x2000
+    case mode = 0x4000
+}

--- a/Sources/SDL1/Mouse.swift
+++ b/Sources/SDL1/Mouse.swift
@@ -1,0 +1,81 @@
+//
+//  Mouse.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+public extension SDL {
+
+    /// The current state of the mouse.
+    static var mouseState: MouseState {
+        var x: CInt = 0
+        var y: CInt = 0
+        let buttons = SDL_GetMouseState(&x, &y)
+        return MouseState(x: Int(x), y: Int(y), buttons: buttons)
+    }
+
+    /// The current relative state of the mouse, i.e. the change since the last query.
+    static var relativeMouseState: MouseState {
+        var x: CInt = 0
+        var y: CInt = 0
+        let buttons = SDL_GetRelativeMouseState(&x, &y)
+        return MouseState(x: Int(x), y: Int(y), buttons: buttons)
+    }
+
+    /// Move the mouse cursor to the given position within the window.
+    static func warpMouse(x: Int, y: Int) {
+        SDL_WarpMouse(UInt16(x), UInt16(y))
+    }
+
+    /// Whether the mouse cursor is shown.
+    static var isCursorVisible: Bool {
+        get { SDL_ShowCursor(-1) == 1 } // SDL_QUERY
+        set { _ = SDL_ShowCursor(newValue ? 1 : 0) }
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension SDL {
+
+    /// A snapshot of the mouse position and button state.
+    struct MouseState: Equatable, Hashable, Sendable {
+
+        public let x: Int
+
+        public let y: Int
+
+        internal let buttons: UInt8
+
+        internal init(x: Int, y: Int, buttons: UInt8) {
+            self.x = x
+            self.y = y
+            self.buttons = buttons
+        }
+
+        /// Whether the given button is currently pressed.
+        public func isPressed(_ button: SDLMouseButton) -> Bool {
+            let mask = UInt8(1) << (button.rawValue - 1)
+            return (buttons & mask) != 0
+        }
+    }
+}
+
+/// A mouse button index.
+public struct SDLMouseButton: RawRepresentable, Equatable, Hashable, Sendable {
+
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static var left: SDLMouseButton { SDLMouseButton(rawValue: 1) }
+    public static var middle: SDLMouseButton { SDLMouseButton(rawValue: 2) }
+    public static var right: SDLMouseButton { SDLMouseButton(rawValue: 3) }
+    public static var wheelUp: SDLMouseButton { SDLMouseButton(rawValue: 4) }
+    public static var wheelDown: SDLMouseButton { SDLMouseButton(rawValue: 5) }
+}

--- a/Sources/SDL1/Palette.swift
+++ b/Sources/SDL1/Palette.swift
@@ -1,0 +1,44 @@
+//
+//  Palette.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL Palette
+///
+/// A non-owning view over the palette of a surface's pixel format. In SDL 1.2 the
+/// palette is owned by the surface; use `SDLSurface.setColors(_:firstColor:)` to modify it.
+public struct SDLPalette {
+
+    // MARK: - Properties
+
+    internal let internalPointer: UnsafeMutablePointer<SDL_Palette>
+
+    // MARK: - Initialization
+
+    internal init(_ internalPointer: UnsafeMutablePointer<SDL_Palette>) {
+        self.internalPointer = internalPointer
+    }
+
+    // MARK: - Accessors
+
+    /// The number of color entries in the palette.
+    public var numberOfColors: Int {
+        return Int(internalPointer.pointee.ncolors)
+    }
+
+    /// The color entries in the palette.
+    public var colors: [SDLColor] {
+        guard let colors = internalPointer.pointee.colors else { return [] }
+        return (0 ..< numberOfColors).map { SDLColor(colors[$0]) }
+    }
+
+    /// Access an individual color entry in the palette.
+    public subscript (index: Int) -> SDLColor {
+        assert(index < numberOfColors, "Invalid index \(index)")
+        return SDLColor(internalPointer.pointee.colors[index])
+    }
+}

--- a/Sources/SDL1/PixelFormat.swift
+++ b/Sources/SDL1/PixelFormat.swift
@@ -1,0 +1,79 @@
+//
+//  PixelFormat.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL Pixel Format
+///
+/// In SDL 1.2 a pixel format is owned by the surface it describes; this type is a
+/// non-owning view over an existing `SDL_PixelFormat` and must not outlive its surface.
+public struct SDLPixelFormat {
+
+    // MARK: - Properties
+
+    internal let internalPointer: UnsafeMutablePointer<SDL_PixelFormat>
+
+    // MARK: - Initialization
+
+    internal init(_ internalPointer: UnsafeMutablePointer<SDL_PixelFormat>) {
+        self.internalPointer = internalPointer
+    }
+
+    // MARK: - Accessors
+
+    /// The number of bits used to represent each pixel.
+    public var bitsPerPixel: UInt8 {
+        return internalPointer.pointee.BitsPerPixel
+    }
+
+    /// The number of bytes used to represent each pixel.
+    public var bytesPerPixel: UInt8 {
+        return internalPointer.pointee.BytesPerPixel
+    }
+
+    /// The bit masks used to extract each color component.
+    public var mask: (red: UInt32, green: UInt32, blue: UInt32, alpha: UInt32) {
+        let format = internalPointer.pointee
+        return (format.Rmask, format.Gmask, format.Bmask, format.Amask)
+    }
+
+    /// The pixel value that is treated as transparent.
+    public var colorKey: UInt32 {
+        return internalPointer.pointee.colorkey
+    }
+
+    /// The overall surface alpha value.
+    public var alpha: UInt8 {
+        return internalPointer.pointee.alpha
+    }
+
+    // MARK: - Methods
+
+    /// Map an RGB color to a pixel value for this format.
+    public func map(red: UInt8, green: UInt8, blue: UInt8) -> UInt32 {
+        return SDL_MapRGB(internalPointer, red, green, blue)
+    }
+
+    /// Map an RGBA color to a pixel value for this format.
+    public func map(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) -> UInt32 {
+        return SDL_MapRGBA(internalPointer, red, green, blue, alpha)
+    }
+
+    /// Get the RGB components of a pixel value for this format.
+    public func components(of pixel: UInt32) -> (red: UInt8, green: UInt8, blue: UInt8) {
+        var components: (red: UInt8, green: UInt8, blue: UInt8) = (0, 0, 0)
+        SDL_GetRGB(pixel, internalPointer, &components.red, &components.green, &components.blue)
+        return components
+    }
+
+    /// Get the RGBA components of a pixel value for this format.
+    public func componentsWithAlpha(of pixel: UInt32) -> (red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) {
+        var components: (red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) = (0, 0, 0, 0)
+        SDL_GetRGBA(pixel, internalPointer, &components.red, &components.green, &components.blue, &components.alpha)
+        return components
+    }
+}

--- a/Sources/SDL1/Rect.swift
+++ b/Sources/SDL1/Rect.swift
@@ -1,0 +1,35 @@
+//
+//  Rect.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// A rectangle, with the origin at the upper left.
+public struct SDLRect: Equatable, Hashable, Sendable {
+
+    public var x: Int16
+    public var y: Int16
+    public var width: UInt16
+    public var height: UInt16
+
+    public init(x: Int16, y: Int16, width: UInt16, height: UInt16) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    internal init(_ internalValue: SDL_Rect) {
+        self.x = internalValue.x
+        self.y = internalValue.y
+        self.width = internalValue.w
+        self.height = internalValue.h
+    }
+
+    internal var internalValue: SDL_Rect {
+        SDL_Rect(x: x, y: y, w: width, h: height)
+    }
+}

--- a/Sources/SDL1/SDL.swift
+++ b/Sources/SDL1/SDL.swift
@@ -1,0 +1,67 @@
+import CSDL
+
+/// [Simple DirectMedia Layer](https://wiki.libsdl.org/SDL_1.2/)
+public struct SDL {
+
+    /// Use this function to initialize the SDL library.
+    /// You should specify the subsystems which you will be using in your application.
+    ///
+    /// - Note: This must be called before using most other SDL functions.
+    public static func initialize(subSystems: BitMaskOptionSet<SubSystem>) throws(SDLError) {
+
+        try SDL_Init(subSystems.rawValue).sdlThrow(type: "SDL")
+    }
+
+    /// Initialize specific SDL subsystems after `initialize(subSystems:)` has been called.
+    public static func initialize(subSystem: BitMaskOptionSet<SubSystem>) throws(SDLError) {
+
+        try SDL_InitSubSystem(subSystem.rawValue).sdlThrow(type: "SDL")
+    }
+
+    /// Cleans up all initialized subsystems.
+    ///
+    /// You should call it upon all exit conditions.
+    @inline(__always)
+    public static func quit() {
+        SDL_Quit()
+    }
+
+    /// Cleans up specific SDL subsystems.
+    public static func quit(subSystems: BitMaskOptionSet<SubSystem>) {
+
+        SDL_QuitSubSystem(subSystems.rawValue)
+    }
+
+    /// The subsystems which have been initialized.
+    public static func wasInitialized(subSystems: BitMaskOptionSet<SubSystem> = .all) -> BitMaskOptionSet<SubSystem> {
+
+        return BitMaskOptionSet<SubSystem>(rawValue: SDL_WasInit(subSystems.rawValue))
+    }
+
+    /// The number of milliseconds since the SDL library initialization.
+    public static var ticks: UInt32 {
+        return SDL_GetTicks()
+    }
+
+    /// Wait the specified number of milliseconds before returning.
+    public static func delay(_ milliseconds: UInt32) {
+        SDL_Delay(milliseconds)
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension SDL {
+
+    /// Specific SDL subsystems.
+    enum SubSystem: UInt32, BitMaskOption {
+
+        case timer = 0x00000001
+        case audio = 0x00000010
+        case video = 0x00000020
+        case cdrom = 0x00000100
+        case joystick = 0x00000200
+        case noParachute = 0x00100000
+        case eventThread = 0x01000000
+    }
+}

--- a/Sources/SDL1/Surface.swift
+++ b/Sources/SDL1/Surface.swift
@@ -1,0 +1,232 @@
+//
+//  Surface.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL Surface
+public final class SDLSurface {
+
+    // MARK: - Properties
+
+    internal let internalPointer: UnsafeMutablePointer<SDL_Surface>
+
+    /// Whether this instance owns (and should free) the underlying surface.
+    ///
+    /// The screen surface returned by `SDL_SetVideoMode` is owned by SDL and must not be freed.
+    internal let owned: Bool
+
+    // MARK: - Initialization
+
+    deinit {
+        if owned {
+            SDL_FreeSurface(internalPointer)
+        }
+    }
+
+    internal init(internalPointer: UnsafeMutablePointer<SDL_Surface>, owned: Bool = true) {
+        self.internalPointer = internalPointer
+        self.owned = owned
+    }
+
+    /// Create an empty RGB surface.
+    public init(
+        rgb mask: (red: UInt32, green: UInt32, blue: UInt32, alpha: UInt32),
+        size: (width: Int, height: Int),
+        depth: Int = 32,
+        flags: BitMaskOptionSet<Flag> = []
+    ) throws(SDLError) {
+
+        let internalPointer = SDL_CreateRGBSurface(flags.rawValue, CInt(size.width), CInt(size.height), CInt(depth), mask.red, mask.green, mask.blue, mask.alpha)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLSurface")
+        self.owned = true
+    }
+
+    /// Adopt an existing, unmanaged `SDL_Surface` pointer (e.g. one returned by `IMG_Load()`).
+    ///
+    /// - Note: Ownership of `pointer` transfers to the new `SDLSurface`; it will be freed
+    ///   via `SDL_FreeSurface` when this instance deinitializes.
+    public init(unsafePointer pointer: UnsafeMutablePointer<SDL_Surface>) {
+        self.internalPointer = pointer
+        self.owned = true
+    }
+
+    /// Load a surface from a BMP file.
+    public init(bmpFile path: String) throws(SDLError) {
+        let internalPointer = SDL_LoadBMP_RW(SDL_RWFromFile(path, "rb"), 1)
+        self.internalPointer = try internalPointer.sdlThrow(type: "SDLSurface")
+        self.owned = true
+    }
+
+    // MARK: - Accessors
+
+    public var width: Int {
+        return Int(internalPointer.pointee.w)
+    }
+
+    public var height: Int {
+        return Int(internalPointer.pointee.h)
+    }
+
+    public var pitch: Int {
+        return Int(internalPointer.pointee.pitch)
+    }
+
+    public var flags: BitMaskOptionSet<Flag> {
+        return BitMaskOptionSet<Flag>(rawValue: internalPointer.pointee.flags)
+    }
+
+    /// The format of the pixels stored in the surface.
+    public var format: SDLPixelFormat {
+        return SDLPixelFormat(internalPointer.pointee.format)
+    }
+
+    /// The palette of the surface, if the pixel format is paletted.
+    public var palette: SDLPalette? {
+        guard let palette = internalPointer.pointee.format.pointee.palette else { return nil }
+        return SDLPalette(palette)
+    }
+
+    internal var mustLock: Bool {
+
+        // #define SDL_MUSTLOCK(surface) (surface->offset || ((surface->flags & (SDL_HWSURFACE|SDL_ASYNCBLIT|SDL_RLEACCEL)) != 0))
+        @inline(__always)
+        get {
+            let surface = internalPointer.pointee
+            let lockFlags = UInt32(SDL_HWSURFACE) | UInt32(SDL_ASYNCBLIT) | UInt32(SDL_RLEACCEL)
+            return surface.offset != 0 || (surface.flags & lockFlags) != 0
+        }
+    }
+
+    // MARK: - Methods
+
+    /// Get a pointer to the data of the surface, for direct inspection or modification.
+    public func withUnsafeMutableBytes<Result, Error>(_ body: (UnsafeMutableRawPointer?) throws(Error) -> Result) throws -> Result where Error: Swift.Error {
+
+        let mustLock = self.mustLock
+
+        if mustLock {
+            try lock()
+        }
+
+        defer {
+            if mustLock {
+                unlock()
+            }
+        }
+
+        return try body(internalPointer.pointee.pixels)
+    }
+
+    /// Sets up a surface for directly accessing the pixels.
+    ///
+    /// Between calls to `lock()` / `unlock()`, you can read from and write to the surface pixels.
+    /// Not all surfaces require locking; consult `mustLock`.
+    internal func lock() throws(SDLError) {
+        try SDL_LockSurface(internalPointer).sdlThrow(type: "SDLSurface")
+    }
+
+    internal func unlock() {
+        SDL_UnlockSurface(internalPointer)
+    }
+
+    /// Perform a fast blit from this surface to the destination surface.
+    public func blit(to surface: SDLSurface, source: SDLRect? = nil, destination: SDLRect? = nil) throws(SDLError) {
+
+        try source.withUnsafeSDLPointer { sourcePointer in
+            destination.withUnsafeSDLPointer { destinationPointer in
+                SDL_UpperBlit(internalPointer, sourcePointer, surface.internalPointer, destinationPointer)
+            }
+        }.sdlThrow(type: "SDLSurface")
+    }
+
+    /// Perform a fast fill of the given rectangle with a mapped pixel value.
+    public func fill(rect: SDLRect? = nil, color: UInt32) throws(SDLError) {
+
+        try rect.withUnsafeSDLPointer { rectPointer in
+            SDL_FillRect(internalPointer, rectPointer, color)
+        }.sdlThrow(type: "SDLSurface")
+    }
+
+    /// Set the transparent color key for the surface, or `nil` to disable color keying.
+    public func setColorKey(_ key: UInt32?) throws(SDLError) {
+        let flag = key == nil ? 0 : (UInt32(SDL_SRCCOLORKEY) | UInt32(SDL_RLEACCEL))
+        try SDL_SetColorKey(internalPointer, flag, key ?? 0).sdlThrow(type: "SDLSurface")
+    }
+
+    /// Set the overall alpha value for the surface, or `nil` to disable alpha blending.
+    public func setAlpha(_ alpha: UInt8?) throws(SDLError) {
+        let flag = alpha == nil ? 0 : UInt32(SDL_SRCALPHA)
+        try SDL_SetAlpha(internalPointer, flag, alpha ?? .max).sdlThrow(type: "SDLSurface")
+    }
+
+    /// Set a range of colors in a paletted surface.
+    ///
+    /// - Returns: `true` if all colors were set exactly as passed.
+    @discardableResult
+    public func setColors(_ colors: [SDLColor], firstColor: Int = 0) -> Bool {
+        var colors = colors.map { $0.internalValue }
+        return SDL_SetColors(internalPointer, &colors, CInt(firstColor), CInt(colors.count)) == 1
+    }
+
+    /// Return a copy of this surface converted to the display format for fast blitting.
+    public func displayFormat(alpha: Bool = false) throws(SDLError) -> SDLSurface {
+        let converted = alpha ? SDL_DisplayFormatAlpha(internalPointer) : SDL_DisplayFormat(internalPointer)
+        return SDLSurface(internalPointer: try converted.sdlThrow(type: "SDLSurface"))
+    }
+
+    /// Save the surface to a BMP file.
+    public func saveBMP(to path: String) throws(SDLError) {
+        try SDL_SaveBMP_RW(internalPointer, SDL_RWFromFile(path, "wb"), 1).sdlThrow(type: "SDLSurface")
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension SDLSurface {
+
+    /// Surface and video mode flags.
+    enum Flag: UInt32, BitMaskOption {
+
+        /// Surface is stored in video memory.
+        case hardwareSurface = 0x00000001
+        /// Create an OpenGL rendering context.
+        case openGL = 0x00000002
+        /// Surface uses asynchronous blits if possible.
+        case asyncBlit = 0x00000004
+        /// Surface is resizable.
+        case resizable = 0x00000010
+        /// No window caption or edge frame.
+        case noFrame = 0x00000020
+        /// Blit uses source color keying.
+        case sourceColorKey = 0x00001000
+        /// Surface is RLE encoded.
+        case rleAccel = 0x00004000
+        /// Blit uses source alpha blending.
+        case sourceAlpha = 0x00010000
+        /// Allow any pixel format for the video surface.
+        case anyFormat = 0x10000000
+        /// Surface has an exclusive palette.
+        case hardwarePalette = 0x20000000
+        /// Surface is double buffered.
+        case doubleBuffer = 0x40000000
+        /// Surface is full screen.
+        case fullscreen = 0x80000000
+    }
+}
+
+// MARK: - Internal Helpers
+
+internal extension Optional where Wrapped == SDLRect {
+
+    /// Call `body` with a pointer to the underlying `SDL_Rect`, or `nil` when absent.
+    func withUnsafeSDLPointer<Result>(_ body: (UnsafeMutablePointer<SDL_Rect>?) -> Result) -> Result {
+        guard var rect = self?.internalValue else {
+            return body(nil)
+        }
+        return withUnsafeMutablePointer(to: &rect, body)
+    }
+}

--- a/Sources/SDL1/Version.swift
+++ b/Sources/SDL1/Version.swift
@@ -1,0 +1,68 @@
+//
+//  Version.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+/// SDL version number.
+public struct SDLVersion: Equatable, Hashable, Sendable {
+
+    public var major: UInt8
+
+    public var minor: UInt8
+
+    public var patch: UInt8
+
+    public init(major: UInt8, minor: UInt8, patch: UInt8) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    internal init(_ version: SDL_version) {
+        self.major = version.major
+        self.minor = version.minor
+        self.patch = version.patch
+    }
+}
+
+public extension SDLVersion {
+
+    /// The version of SDL the application was compiled against.
+    static var compiled: SDLVersion {
+        SDLVersion(
+            major: UInt8(SDL_MAJOR_VERSION),
+            minor: UInt8(SDL_MINOR_VERSION),
+            patch: UInt8(SDL_PATCHLEVEL)
+        )
+    }
+
+    /// The version of SDL that is linked against the application at runtime.
+    static var linked: SDLVersion {
+        guard let pointer = SDL_Linked_Version() else {
+            return .compiled
+        }
+        return SDLVersion(pointer.pointee)
+    }
+}
+
+// MARK: - Comparable
+
+extension SDLVersion: Comparable {
+
+    public static func < (lhs: SDLVersion, rhs: SDLVersion) -> Bool {
+        return (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension SDLVersion: CustomStringConvertible {
+
+    public var description: String {
+        return "\(major).\(minor).\(patch)"
+    }
+}

--- a/Sources/SDL1/Video.swift
+++ b/Sources/SDL1/Video.swift
@@ -1,0 +1,129 @@
+//
+//  Video.swift
+//  SDL1
+//
+//  Created by Alsey Coleman Miller on 7/10/26.
+//
+
+import CSDL
+
+public extension SDL {
+
+    /// Set up a video mode with the specified width, height and bits-per-pixel.
+    ///
+    /// - Returns: The screen surface. This surface is owned by SDL and is freed by `SDL.quit()`.
+    @discardableResult
+    static func setVideoMode(
+        width: Int,
+        height: Int,
+        bitsPerPixel: Int = 0,
+        flags: BitMaskOptionSet<SDLSurface.Flag> = []
+    ) throws(SDLError) -> SDLSurface {
+
+        let internalPointer = SDL_SetVideoMode(CInt(width), CInt(height), CInt(bitsPerPixel), flags.rawValue)
+        return SDLSurface(internalPointer: try internalPointer.sdlThrow(type: "SDLSurface"), owned: false)
+    }
+
+    /// The current display surface, if a video mode has been set.
+    static var videoSurface: SDLSurface? {
+        guard let internalPointer = SDL_GetVideoSurface() else { return nil }
+        return SDLSurface(internalPointer: internalPointer, owned: false)
+    }
+
+    /// Check whether a video mode is supported.
+    ///
+    /// - Returns: `0` if the mode is not supported, otherwise the bits-per-pixel of the closest match.
+    static func videoModeSupported(
+        width: Int,
+        height: Int,
+        bitsPerPixel: Int,
+        flags: BitMaskOptionSet<SDLSurface.Flag> = []
+    ) -> Int {
+        return Int(SDL_VideoModeOK(CInt(width), CInt(height), CInt(bitsPerPixel), flags.rawValue))
+    }
+
+    /// Swap the screen buffers, updating the display.
+    static func flip(_ screen: SDLSurface) throws(SDLError) {
+        try SDL_Flip(screen.internalPointer).sdlThrow(type: "SDLSurface")
+    }
+
+    /// Make sure the given area of the screen is updated.
+    ///
+    /// Passing a `nil` rectangle updates the entire screen.
+    static func update(_ screen: SDLSurface, rect: SDLRect? = nil) {
+        if let rect {
+            SDL_UpdateRect(screen.internalPointer, Int32(rect.x), Int32(rect.y), UInt32(rect.width), UInt32(rect.height))
+        } else {
+            SDL_UpdateRect(screen.internalPointer, 0, 0, 0, 0)
+        }
+    }
+
+    /// Make sure the given list of areas of the screen are updated.
+    static func update(_ screen: SDLSurface, rects: [SDLRect]) {
+        var rects = rects.map { $0.internalValue }
+        SDL_UpdateRects(screen.internalPointer, CInt(rects.count), &rects)
+    }
+
+    /// Set the title and icon text of the display window.
+    static func setCaption(title: String, icon: String? = nil) {
+        SDL_WM_SetCaption(title, icon ?? title)
+    }
+
+    /// Set the icon for the display window.
+    static func setIcon(_ surface: SDLSurface) {
+        SDL_WM_SetIcon(surface.internalPointer, nil)
+    }
+
+    /// Iconify (minimize) the display window.
+    @discardableResult
+    static func iconifyWindow() -> Bool {
+        return SDL_WM_IconifyWindow() != 0
+    }
+
+    /// Toggle between full screen and windowed mode.
+    @discardableResult
+    static func toggleFullScreen(_ screen: SDLSurface) -> Bool {
+        return SDL_WM_ToggleFullScreen(screen.internalPointer) != 0
+    }
+}
+
+// MARK: - Supporting Types
+
+public extension SDL {
+
+    /// Information about the video hardware.
+    struct VideoInfo {
+
+        internal let internalValue: SDL_VideoInfo
+
+        /// Get information about the video hardware.
+        public init() {
+            self.internalValue = SDL_GetVideoInfo().pointee
+        }
+
+        /// Whether it is possible to create hardware surfaces.
+        public var hardwareAvailable: Bool {
+            return internalValue.hw_available != 0
+        }
+
+        /// Whether a window manager is available.
+        public var windowManagerAvailable: Bool {
+            return internalValue.wm_available != 0
+        }
+
+        /// The total amount of video memory, in kilobytes.
+        public var videoMemory: Int {
+            return Int(internalValue.video_mem)
+        }
+
+        /// The width of the current video mode, in pixels.
+        public var currentWidth: Int {
+            return Int(internalValue.current_w)
+        }
+
+        /// The height of the current video mode, in pixels.
+        public var currentHeight: Int {
+            return Int(internalValue.current_h)
+        }
+    }
+}

--- a/Tests/SDL1Tests/SDL1Tests.swift
+++ b/Tests/SDL1Tests/SDL1Tests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import SDL1Swift
+
+class SDL1Tests: XCTestCase {
+
+    func testVersion() {
+
+        let linked = SDLVersion.linked
+        print("Linked SDL version:", linked)
+        XCTAssertEqual(linked.major, 1)
+        XCTAssertEqual(SDLVersion.compiled.major, 1)
+        XCTAssertEqual(SDLVersion.compiled.minor, 2)
+    }
+
+    func testSubSystemFlags() {
+
+        let subsystems: BitMaskOptionSet<SDL.SubSystem> = [.video, .audio]
+        XCTAssert(subsystems.contains(.video))
+        XCTAssert(subsystems.contains(.audio))
+        XCTAssertFalse(subsystems.contains(.joystick))
+    }
+
+    func testMouseButton() {
+
+        XCTAssertEqual(SDLMouseButton.left.rawValue, 1)
+        XCTAssertEqual(SDLMouseButton.right.rawValue, 3)
+    }
+}


### PR DESCRIPTION
Adds Swift wrappers for the SDL 1.2 API, mirroring the structure and style of the existing `SDL2Swift` / `SDL3Swift` targets. Backed by the `sdl12-compat` system library via a new `CSDL` system library target.

## New target
- `SDL1Swift` library product + `SDL1Tests` test target, backed by `CSDL` (`pkgConfig: "sdl"`, brew `sdl12-compat` / apt `libsdl1.2-compat-dev`).

## Wrappers (one commit per file)
- **BitMaskOption** / **CountableSet** — shared utilities (OptionSet-style flags, stack collection).
- **Error** — `SDLError`, `SDL_GetError` bridging, and the `sdlThrow` helpers.
- **SDL** — `initialize`/`quit`, subsystems, `wasInitialized`, `ticks`, `delay`.
- **Version** — compiled vs. linked `SDL_version`.
- **Rect** — `SDL_Rect` value type.
- **Color** — palette color entry (SDL 1.2 colors carry no alpha).
- **PixelFormat** — non-owning pixel format view + RGB(A) map/unmap.
- **Palette** — non-owning surface palette view.
- **Surface** — create/load surfaces, blitting, fill, color key / alpha, locking + pixel access, display-format conversion, BMP save; ownership-aware so the SDL-owned screen surface is never freed.
- **Video** — `setVideoMode`, `videoSurface`, `flip`, `update`, WM caption/icon, fullscreen toggle, `VideoInfo`.
- **Event** — `pollEvent` / `waitEvent` and a typed `SDLEvent` enum.
- **Keyboard** — key state snapshot, `SDLKeycode`, `SDLKeyModifier`, key repeat, Unicode toggle.
- **Mouse** — mouse/relative state, warp, cursor visibility, `SDLMouseButton`.
- **Cursor** — custom monochrome cursor creation and activation.
- **Joystick** — enumeration and axis/button/hat/ball input.

## Verification
`swift build` succeeds for the whole package and all three `SDL1Tests` cases pass (linked against SDL 1.2.76).